### PR TITLE
feat(json_schema): Draft 7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ chrono = "0.4.6"
 publicsuffix = { version = "1.5.4", default-features = false }
 percent-encoding = "2.1"
 json-pointer = "0.3"
+base64 = "0.12.3"
 
 [build-dependencies.phf_codegen]
 version = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ phf = "0.8"
 serde = "1.0"
 serde_json = "1.0"
 chrono = "0.4.6"
-publicsuffix = { version = "1.5.2", default-features = false }
+publicsuffix = { version = "1.5.4", default-features = false }
 percent-encoding = "2.1"
 json-pointer = "0.3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,8 @@ serde_json = "1.0"
 chrono = "0.4.6"
 publicsuffix = { version = "1.5.4", default-features = false }
 percent-encoding = "2.1"
-json-pointer = "0.3"
+json-pointer = "0.3.2"
+uritemplate = "0.1.2"
 base64 = "0.12.3"
 
 [build-dependencies.phf_codegen]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1.0"
 chrono = "0.4.6"
 publicsuffix = { version = "1.5.2", default-features = false }
 percent-encoding = "2.1"
+json-pointer = "0.3"
 
 [build-dependencies.phf_codegen]
 version = "0.8"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Valico is a validation and coercion tool for JSON objects, written in Rust. It d
 Valico has two features:
 
 * **DSL** — a set of simple validators and coercers inspired by [Grape]. It has built-in support for common coercers, validators and can return detailed error messages if something goes wrong.
-* **JSON Schema** — An implementation of JSON Schema, based on IETF's draft v6.
+* **JSON Schema** — An implementation of JSON Schema, based on IETF's draft v7.
 
 References:
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ use valico::json_schema;
 use std::fs::File;
 
 fn main() {
-    let json_v4_schema: Value = serde_json::from_reader(File::open("tests/schema/schema.json").unwrap()).unwrap();
+    let json_schema: Value = serde_json::from_reader(File::open("tests/schema/schema.json").unwrap()).unwrap();
 
     let mut scope = json_schema::Scope::new();
     let schema = scope.compile_and_return(json_v4_schema.clone(), false).unwrap();

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -60,15 +60,11 @@ pub type ValicoErrors = Vec<Box<dyn ValicoError>>;
 
 macro_rules! impl_basic_err {
     ($err:ty, $code:expr) => {
-        impl ::std::error::Error for $err {
-            fn description(&self) -> &str {
-                $code
-            }
-        }
+        impl ::std::error::Error for $err {}
 
         impl ::std::fmt::Display for $err {
             fn fmt(&self, formatter: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                self.description().fmt(formatter)
+                write!(formatter, $code)
             }
         }
     };

--- a/src/json_dsl/errors.rs
+++ b/src/json_dsl/errors.rs
@@ -1,7 +1,6 @@
 use super::super::common::error::ValicoError;
 use serde::{Serialize, Serializer};
 use serde_json::{to_value, Value};
-use std::error::Error;
 
 #[derive(Debug)]
 #[allow(missing_copy_implementations)]

--- a/src/json_schema/builder.rs
+++ b/src/json_schema/builder.rs
@@ -362,6 +362,30 @@ impl Builder {
     pub fn into_json(self) -> Value {
         self.obj_builder.unwrap()
     }
+
+    pub fn if_<F>(&mut self, build: F)
+    where
+        F: FnOnce(&mut Builder),
+    {
+        self.obj_builder
+            .set("if", Builder::build(build).into_json())
+    }
+
+    pub fn then_<F>(&mut self, build: F)
+    where
+        F: FnOnce(&mut Builder),
+    {
+        self.obj_builder
+            .set("then", Builder::build(build).into_json())
+    }
+
+    pub fn else_<F>(&mut self, build: F)
+    where
+        F: FnOnce(&mut Builder),
+    {
+        self.obj_builder
+            .set("else", Builder::build(build).into_json())
+    }
 }
 
 impl Serialize for Builder {

--- a/src/json_schema/builder.rs
+++ b/src/json_schema/builder.rs
@@ -363,6 +363,14 @@ impl Builder {
         self.obj_builder.unwrap()
     }
 
+    pub fn content_media_type(&mut self, type_: super::keywords::content_media::ContentMediaType) {
+        self.obj_builder.set("contentMediaType", type_.as_str())
+    }
+
+    pub fn content_encoding(&mut self, type_: super::keywords::content_media::ContentEncoding) {
+        self.obj_builder.set("contentEncoding", type_.as_str())
+    }
+
     pub fn if_<F>(&mut self, build: F)
     where
         F: FnOnce(&mut Builder),

--- a/src/json_schema/errors.rs
+++ b/src/json_schema/errors.rs
@@ -1,7 +1,6 @@
 use super::super::common::error::ValicoError;
 use serde::{Serialize, Serializer};
 use serde_json::{to_value, Value};
-use std::error::Error;
 
 #[derive(Debug)]
 #[allow(missing_copy_implementations)]

--- a/src/json_schema/helpers.rs
+++ b/src/json_schema/helpers.rs
@@ -12,13 +12,15 @@ pub fn generate_id() -> Url {
 
 /// http://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-07
 pub fn encode(string: &str) -> String {
-    const QUERY_SET: percent_encoding::AsciiSet =
-        percent_encoding::CONTROLS.add(b' ').add(b'"').add(b'#').add(b'<').add(b'>').add(b'%');
+    const QUERY_SET: percent_encoding::AsciiSet = percent_encoding::CONTROLS
+        .add(b' ')
+        .add(b'"')
+        .add(b'#')
+        .add(b'<')
+        .add(b'>')
+        .add(b'%');
     percent_encoding::percent_encode(
-        string
-            .replace("~", "~0")
-            .replace("/", "~1")
-            .as_bytes(),
+        string.replace("~", "~0").replace("/", "~1").as_bytes(),
         &QUERY_SET,
     )
     .to_string()

--- a/src/json_schema/keywords/conditional.rs
+++ b/src/json_schema/keywords/conditional.rs
@@ -1,0 +1,102 @@
+use serde_json::Value;
+
+use super::super::helpers;
+use super::super::schema;
+use super::super::validators;
+
+#[allow(missing_copy_implementations)]
+pub struct Conditional;
+impl super::Keyword for Conditional {
+    fn compile(&self, def: &Value, ctx: &schema::WalkContext<'_>) -> super::KeywordResult {
+        let maybe_if = def.get("if");
+        let maybe_then = def.get("then");
+        let maybe_else = def.get("else");
+
+        if maybe_if.is_none() {
+            Ok(None)
+        } else {
+            let if_ = helpers::alter_fragment_path(
+                ctx.url.clone(),
+                [ctx.escaped_fragment().as_ref(), "if"].join("/"),
+            );
+            let then_ = match maybe_then {
+                Some(_) => Some(helpers::alter_fragment_path(
+                    ctx.url.clone(),
+                    [ctx.escaped_fragment().as_ref(), "then"].join("/"),
+                )),
+                None => None,
+            };
+            let else_ = match maybe_else {
+                Some(_) => Some(helpers::alter_fragment_path(
+                    ctx.url.clone(),
+                    [ctx.escaped_fragment().as_ref(), "else"].join("/"),
+                )),
+                None => None,
+            };
+            Ok(Some(Box::new(validators::Conditional {
+                if_,
+                then_,
+                else_,
+            })))
+        }
+    }
+}
+
+#[cfg(test)]
+use super::super::builder;
+#[cfg(test)]
+use super::super::scope;
+#[cfg(test)]
+use serde_json::to_value;
+
+#[test]
+fn validate_if_then() {
+    let mut scope = scope::Scope::new();
+    let schema = scope.compile_and_return(
+        builder::schema(|s| {
+            s.if_(|if_| {
+                if_.minimum(5f64);
+            });
+            s.then_(|then_| {
+                then_.minimum(5f64);
+                then_.maximum(10f64);
+            });
+        })
+        .into_json(),
+        true,
+    );
+
+    assert!(!schema.is_err(), schema.err().unwrap().to_string());
+
+    let s = schema.unwrap();
+    assert_eq!(s.validate(&to_value(3).unwrap()).is_valid(), true);
+    assert_eq!(s.validate(&to_value(15).unwrap()).is_valid(), false);
+}
+
+#[test]
+fn validate_if_then_else() {
+    let mut scope = scope::Scope::new();
+    let schema = scope.compile_and_return(
+        builder::schema(|s| {
+            s.if_(|if_| {
+                if_.minimum(5f64);
+            });
+            s.then_(|then_| {
+                then_.minimum(5f64);
+                then_.maximum(10f64);
+            });
+            s.else_(|else_| {
+                else_.minimum(1f64);
+                else_.maximum(4f64);
+            });
+        })
+        .into_json(),
+        true,
+    );
+
+    assert!(!schema.is_err(), schema.err().unwrap().to_string());
+
+    let s = schema.unwrap();
+    assert_eq!(s.validate(&to_value(3).unwrap()).is_valid(), true);
+    assert_eq!(s.validate(&to_value(0).unwrap()).is_valid(), false);
+}

--- a/src/json_schema/keywords/content_media.rs
+++ b/src/json_schema/keywords/content_media.rs
@@ -1,0 +1,125 @@
+use base64;
+use serde_json::Value;
+use std::str;
+
+use super::super::schema;
+use super::super::validators;
+
+#[derive(Debug)]
+pub enum ContentMediaType {
+    ApplicationJson,
+}
+
+impl ContentMediaType {
+    pub fn as_str(&self) -> &str {
+        match self {
+            &ContentMediaType::ApplicationJson => "application/json",
+        }
+    }
+
+    pub fn validate(&self, val: &str) -> bool {
+        match self {
+            &ContentMediaType::ApplicationJson => serde_json::from_str::<Value>(val),
+        }
+        .is_ok()
+    }
+}
+
+impl str::FromStr for ContentMediaType {
+    type Err = ();
+    fn from_str(s: &str) -> Result<ContentMediaType, ()> {
+        match s {
+            "application/json" => Ok(ContentMediaType::ApplicationJson),
+            _ => Err(()),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ContentEncoding {
+    Base64,
+}
+
+// pub struct DecodeError(String);
+
+impl ContentEncoding {
+    pub fn as_str(&self) -> &str {
+        match self {
+            &ContentEncoding::Base64 => "base64",
+        }
+    }
+
+    pub fn decode_val(&self, val: &str) -> Result<String, String> {
+        match self {
+            &ContentEncoding::Base64 => match base64::decode(val) {
+                Ok(v) => match str::from_utf8(&v[..]) {
+                    Ok(s) => Ok(s.to_string()),
+                    Err(e) => Err(e.to_string()),
+                },
+                Err(e) => Err(e.to_string()),
+            },
+        }
+    }
+}
+
+impl str::FromStr for ContentEncoding {
+    type Err = ();
+    fn from_str(s: &str) -> Result<ContentEncoding, ()> {
+        match s {
+            "base64" => Ok(ContentEncoding::Base64),
+            _ => Err(()),
+        }
+    }
+}
+
+#[allow(missing_copy_implementations)]
+pub struct ContentMedia;
+impl super::Keyword for ContentMedia {
+    fn compile(&self, def: &Value, ctx: &schema::WalkContext<'_>) -> super::KeywordResult {
+        let maybe_content_media_type = def.get("contentMediaType");
+        let mut type_ = None;
+        if maybe_content_media_type.is_some() {
+            let content_media_type = maybe_content_media_type.unwrap();
+            if !content_media_type.is_string() {
+                return Err(schema::SchemaError::Malformed {
+                    path: ctx.fragment.join("/"),
+                    detail: "contentMediaType MUST be a string.".to_string(),
+                });
+            } else {
+                let media_type = content_media_type.as_str().unwrap().parse().ok();
+                if media_type.is_none() {
+                    return Err(schema::SchemaError::Malformed {
+                        path: ctx.fragment.join("/"),
+                        detail: "contentMediaType MUST be a string.".to_string(),
+                    });
+                } else {
+                    type_ = Some(media_type.unwrap());
+                }
+            }
+        }
+
+        let maybe_content_encoding = def.get("contentEncoding");
+        let mut encoding = None;
+        if maybe_content_encoding.is_some() {
+            let content_encoding = maybe_content_encoding.unwrap();
+            if !content_encoding.is_string() {
+                return Err(schema::SchemaError::Malformed {
+                    path: ctx.fragment.join("/"),
+                    detail: "contentEncoding MUST be a string.".to_string(),
+                });
+            } else {
+                let encoding_ = content_encoding.as_str().unwrap().parse().ok();
+                if encoding_.is_none() {
+                    return Err(schema::SchemaError::Malformed {
+                        path: ctx.fragment.join("/"),
+                        detail: "contentEncoding MUST be a string.".to_string(),
+                    });
+                } else {
+                    encoding = Some(encoding_.unwrap());
+                }
+            }
+        }
+
+        Ok(Some(Box::new(validators::ContentMedia { type_, encoding })))
+    }
+}

--- a/src/json_schema/keywords/content_media.rs
+++ b/src/json_schema/keywords/content_media.rs
@@ -40,8 +40,6 @@ pub enum ContentEncoding {
     Base64,
 }
 
-// pub struct DecodeError(String);
-
 impl ContentEncoding {
     pub fn as_str(&self) -> &str {
         match self {
@@ -90,7 +88,8 @@ impl super::Keyword for ContentMedia {
                 if media_type.is_none() {
                     return Err(schema::SchemaError::Malformed {
                         path: ctx.fragment.join("/"),
-                        detail: "contentMediaType MUST be a string.".to_string(),
+                        detail: "contentMediaType MUST be one of [\"application/json\"]"
+                            .to_string(),
                     });
                 } else {
                     type_ = Some(media_type.unwrap());
@@ -112,7 +111,7 @@ impl super::Keyword for ContentMedia {
                 if encoding_.is_none() {
                     return Err(schema::SchemaError::Malformed {
                         path: ctx.fragment.join("/"),
-                        detail: "contentEncoding MUST be a string.".to_string(),
+                        detail: "contentEncoding MUST be one of [\"base64\"]".to_string(),
                     });
                 } else {
                     encoding = Some(encoding_.unwrap());

--- a/src/json_schema/keywords/format.rs
+++ b/src/json_schema/keywords/format.rs
@@ -241,17 +241,19 @@ fn validate_time() {
         schema
             .validate(&to_value(&"17:35:20-08:00").unwrap())
             .is_valid(),
-        true
+        false
     );
-    // assert_eq!(
-    //     schema.validate(&to_value(&"04:04:00Z").unwrap()).is_valid(),
-    //     true
-    // );
+    assert_eq!(
+        schema
+            .validate(&to_value(&"04:04:00.040404Z").unwrap())
+            .is_valid(),
+        false // https://github.com/chronotope/chrono/issues/288
+    );
     assert_eq!(
         schema
             .validate(&to_value(&"17:35:20 -0800").unwrap())
             .is_valid(),
-        true
+        false
     );
 }
 

--- a/src/json_schema/keywords/format.rs
+++ b/src/json_schema/keywords/format.rs
@@ -37,6 +37,13 @@ fn default_formats() -> FormatBuilders {
     });
     map.insert("hostname".to_string(), hostname_builder);
 
+    let idn_hostname_builder = Box::new(|_def: &Value, _ctx: &schema::WalkContext<'_>| {
+        Ok(Some(
+            Box::new(validators::formats::Hostname) as validators::BoxedValidator
+        ))
+    });
+    map.insert("idn-hostname".to_string(), idn_hostname_builder);
+
     let ipv4_builder = Box::new(|_def: &Value, _ctx: &schema::WalkContext<'_>| {
         Ok(Some(
             Box::new(validators::formats::Ipv4) as validators::BoxedValidator

--- a/src/json_schema/keywords/format.rs
+++ b/src/json_schema/keywords/format.rs
@@ -37,6 +37,13 @@ fn default_formats() -> FormatBuilders {
     });
     map.insert("hostname".to_string(), hostname_builder);
 
+    let idn_email_builder = Box::new(|_def: &Value, _ctx: &schema::WalkContext<'_>| {
+        Ok(Some(
+            Box::new(validators::formats::Email) as validators::BoxedValidator
+        ))
+    });
+    map.insert("idn-email".to_string(), idn_email_builder);
+
     let idn_hostname_builder = Box::new(|_def: &Value, _ctx: &schema::WalkContext<'_>| {
         Ok(Some(
             Box::new(validators::formats::Hostname) as validators::BoxedValidator
@@ -58,12 +65,43 @@ fn default_formats() -> FormatBuilders {
     });
     map.insert("ipv6".to_string(), ipv6_builder);
 
+    let iri_builder = Box::new(|_def: &Value, _ctx: &schema::WalkContext<'_>| {
+        Ok(Some(
+            Box::new(validators::formats::IRI) as validators::BoxedValidator
+        ))
+    });
+    map.insert("iri".to_string(), iri_builder);
+
+    let iri_reference_builder = Box::new(|_def: &Value, _ctx: &schema::WalkContext<'_>| {
+        Ok(Some(
+            Box::new(validators::formats::IRIReference) as validators::BoxedValidator
+        ))
+    });
+    map.insert("iri-reference".to_string(), iri_reference_builder);
+
     let json_pointer_builder = Box::new(|_def: &Value, _ctx: &schema::WalkContext<'_>| {
         Ok(Some(
             Box::new(validators::formats::JsonPointer) as validators::BoxedValidator
         ))
     });
     map.insert("json-pointer".to_string(), json_pointer_builder);
+
+    let regex_builder = Box::new(|_def: &Value, _ctx: &schema::WalkContext<'_>| {
+        Ok(Some(
+            Box::new(validators::formats::Regex) as validators::BoxedValidator
+        ))
+    });
+    map.insert("regex".to_string(), regex_builder);
+
+    let relative_json_pointer_builder = Box::new(|_def: &Value, _ctx: &schema::WalkContext<'_>| {
+        Ok(Some(
+            Box::new(validators::formats::RelativeJsonPointer) as validators::BoxedValidator
+        ))
+    });
+    map.insert(
+        "relative-json-pointer".to_string(),
+        relative_json_pointer_builder,
+    );
 
     let time_builder = Box::new(|_def: &Value, _ctx: &schema::WalkContext<'_>| {
         Ok(Some(
@@ -85,6 +123,13 @@ fn default_formats() -> FormatBuilders {
         ))
     });
     map.insert("uri-reference".to_string(), uri_reference_builder);
+
+    let uri_template_builder = Box::new(|_def: &Value, _ctx: &schema::WalkContext<'_>| {
+        Ok(Some(
+            Box::new(validators::formats::UriTemplate) as validators::BoxedValidator
+        ))
+    });
+    map.insert("uri-template".to_string(), uri_template_builder);
 
     let uuid_builder = Box::new(|_def: &Value, _ctx: &schema::WalkContext<'_>| {
         Ok(Some(

--- a/src/json_schema/keywords/format.rs
+++ b/src/json_schema/keywords/format.rs
@@ -51,6 +51,13 @@ fn default_formats() -> FormatBuilders {
     });
     map.insert("ipv6".to_string(), ipv6_builder);
 
+    let json_pointer_builder = Box::new(|_def: &Value, _ctx: &schema::WalkContext<'_>| {
+        Ok(Some(
+            Box::new(validators::formats::JsonPointer) as validators::BoxedValidator
+        ))
+    });
+    map.insert("json-pointer".to_string(), json_pointer_builder);
+
     let time_builder = Box::new(|_def: &Value, _ctx: &schema::WalkContext<'_>| {
         Ok(Some(
             Box::new(validators::formats::Time) as validators::BoxedValidator
@@ -336,6 +343,30 @@ fn validate_ipv6() {
     );
     assert_eq!(
         schema.validate(&to_value(&"127.0.0.1").unwrap()).is_valid(),
+        false
+    );
+}
+
+#[test]
+fn validate_json_pointer() {
+    let mut scope = scope::Scope::new();
+    let schema = scope
+        .compile_and_return(
+            builder::schema(|s| {
+                s.format("json-pointer");
+            })
+            .into_json(),
+            true,
+        )
+        .ok()
+        .unwrap();
+
+    assert_eq!(
+        schema.validate(&to_value(&"/foo/bar").unwrap()).is_valid(),
+        true
+    );
+    assert_eq!(
+        schema.validate(&to_value(&"pointer").unwrap()).is_valid(),
         false
     );
 }

--- a/src/json_schema/keywords/maxmin_items.rs
+++ b/src/json_schema/keywords/maxmin_items.rs
@@ -27,7 +27,7 @@ fn validate_max_items() {
             true,
         )
         .ok()
-        .unwrap();;
+        .unwrap();
 
     assert_eq!(
         schema
@@ -96,7 +96,7 @@ fn validate_min_items() {
             true,
         )
         .ok()
-        .unwrap();;
+        .unwrap();
 
     assert_eq!(
         schema

--- a/src/json_schema/keywords/maxmin_length.rs
+++ b/src/json_schema/keywords/maxmin_length.rs
@@ -58,7 +58,7 @@ fn validate_max_length() {
             true,
         )
         .ok()
-        .unwrap();;
+        .unwrap();
 
     assert_eq!(
         schema.validate(&to_value(&"1234").unwrap()).is_valid(),
@@ -121,7 +121,7 @@ fn validate_min_length() {
             true,
         )
         .ok()
-        .unwrap();;
+        .unwrap();
 
     assert_eq!(
         schema.validate(&to_value(&"1234").unwrap()).is_valid(),

--- a/src/json_schema/keywords/maxmin_properties.rs
+++ b/src/json_schema/keywords/maxmin_properties.rs
@@ -116,7 +116,7 @@ fn validate_min_properties() {
             true,
         )
         .ok()
-        .unwrap();;
+        .unwrap();
 
     assert_eq!(
         schema

--- a/src/json_schema/keywords/mod.rs
+++ b/src/json_schema/keywords/mod.rs
@@ -51,6 +51,7 @@ pub mod maxmin_length;
 pub mod conditional;
 pub mod const_;
 pub mod contains;
+pub mod content_media;
 pub mod dependencies;
 pub mod enum_;
 pub mod format;
@@ -151,6 +152,14 @@ pub fn default() -> KeywordMap {
     decouple_keyword((vec!["type"], Box::new(type_::Type)), &mut map);
     decouple_keyword(
         (vec!["uniqueItems"], Box::new(unique_items::UniqueItems)),
+        &mut map,
+    );
+
+    decouple_keyword(
+        (
+            vec!["contentMediaType", "contentEncoding"],
+            Box::new(content_media::ContentMedia),
+        ),
         &mut map,
     );
 

--- a/src/json_schema/keywords/mod.rs
+++ b/src/json_schema/keywords/mod.rs
@@ -1,8 +1,8 @@
 use serde_json::Value;
+use std::any;
+use std::collections;
 use std::fmt;
 use std::sync::Arc;
-use std::collections;
-use std::any;
 
 use super::schema;
 use super::validators;
@@ -48,6 +48,7 @@ macro_rules! keyword_key_exists {
 #[macro_use]
 pub mod maxmin_length;
 
+pub mod conditional;
 pub mod const_;
 pub mod contains;
 pub mod dependencies;
@@ -81,16 +82,49 @@ pub fn default() -> KeywordMap {
         &mut map,
     );
     decouple_keyword((vec!["enum"], Box::new(enum_::Enum)), &mut map);
-    decouple_keyword((vec!["exclusiveMaximum"], Box::new(maxmin::ExclusiveMaximum)), &mut map);
-    decouple_keyword((vec!["exclusiveMinimum"], Box::new(maxmin::ExclusiveMinimum)), &mut map);
-    decouple_keyword((vec!["items", "additionalItems"], Box::new(items::Items)), &mut map);
-    decouple_keyword((vec!["maxItems"], Box::new(maxmin_items::MaxItems)), &mut map);
-    decouple_keyword((vec!["maxLength"], Box::new(maxmin_length::MaxLength)), &mut map);
-    decouple_keyword((vec!["maxProperties"], Box::new(maxmin_properties::MaxProperties)), &mut map);
+    decouple_keyword(
+        (vec!["exclusiveMaximum"], Box::new(maxmin::ExclusiveMaximum)),
+        &mut map,
+    );
+    decouple_keyword(
+        (vec!["exclusiveMinimum"], Box::new(maxmin::ExclusiveMinimum)),
+        &mut map,
+    );
+    decouple_keyword(
+        (vec!["items", "additionalItems"], Box::new(items::Items)),
+        &mut map,
+    );
+    decouple_keyword(
+        (vec!["maxItems"], Box::new(maxmin_items::MaxItems)),
+        &mut map,
+    );
+    decouple_keyword(
+        (vec!["maxLength"], Box::new(maxmin_length::MaxLength)),
+        &mut map,
+    );
+    decouple_keyword(
+        (
+            vec!["maxProperties"],
+            Box::new(maxmin_properties::MaxProperties),
+        ),
+        &mut map,
+    );
     decouple_keyword((vec!["maximum"], Box::new(maxmin::Maximum)), &mut map);
-    decouple_keyword((vec!["minItems"], Box::new(maxmin_items::MinItems)), &mut map);
-    decouple_keyword((vec!["minLength"], Box::new(maxmin_length::MinLength)), &mut map);
-    decouple_keyword((vec!["minProperties"], Box::new(maxmin_properties::MinProperties)), &mut map);
+    decouple_keyword(
+        (vec!["minItems"], Box::new(maxmin_items::MinItems)),
+        &mut map,
+    );
+    decouple_keyword(
+        (vec!["minLength"], Box::new(maxmin_length::MinLength)),
+        &mut map,
+    );
+    decouple_keyword(
+        (
+            vec!["minProperties"],
+            Box::new(maxmin_properties::MinProperties),
+        ),
+        &mut map,
+    );
     decouple_keyword((vec!["minimum"], Box::new(maxmin::Minimum)), &mut map);
     decouple_keyword(
         (vec!["multipleOf"], Box::new(multiple_of::MultipleOf)),
@@ -117,6 +151,14 @@ pub fn default() -> KeywordMap {
     decouple_keyword((vec!["type"], Box::new(type_::Type)), &mut map);
     decouple_keyword(
         (vec!["uniqueItems"], Box::new(unique_items::UniqueItems)),
+        &mut map,
+    );
+
+    decouple_keyword(
+        (
+            vec!["if", "then", "else"],
+            Box::new(conditional::Conditional),
+        ),
         &mut map,
     );
 

--- a/src/json_schema/keywords/type_.rs
+++ b/src/json_schema/keywords/type_.rs
@@ -77,16 +77,6 @@ use jsonway;
 #[cfg(test)]
 use serde_json::to_value;
 
-// pub enum PrimitiveType {
-//     Array,
-//     Boolean,
-//     Integer,
-//     Number,
-//     Null,
-//     Object,
-//     String,
-// }
-
 #[test]
 fn validate_array() {
     let mut scope = scope::Scope::new();

--- a/src/json_schema/keywords/unique_items.rs
+++ b/src/json_schema/keywords/unique_items.rs
@@ -37,7 +37,7 @@ fn validate_unique_items() {
     let schema = scope
         .compile_and_return(builder::schema(|s| s.unique_items(true)).into_json(), true)
         .ok()
-        .unwrap();;
+        .unwrap();
 
     assert_eq!(
         schema

--- a/src/json_schema/validators/conditional.rs
+++ b/src/json_schema/validators/conditional.rs
@@ -1,0 +1,51 @@
+use serde_json::Value;
+use url;
+
+use super::super::scope;
+
+#[allow(missing_copy_implementations)]
+pub struct Conditional {
+    pub if_: url::Url,
+    pub then_: Option<url::Url>,
+    pub else_: Option<url::Url>,
+}
+
+impl super::Validator for Conditional {
+    fn validate(&self, val: &Value, path: &str, scope: &scope::Scope) -> super::ValidationState {
+        let mut state = super::ValidationState::new();
+
+        let schema_if_ = scope.resolve(&self.if_);
+        if schema_if_.is_some() {
+            let schema_if = schema_if_.unwrap();
+
+            // TODO should the validation be strict?
+            let if_path = [path, "if"].join("/");
+            if schema_if.validate_in(val, if_path.as_ref()).is_valid() {
+                if self.then_.is_some() {
+                    let schema_then_ = scope.resolve(&self.then_.as_ref().unwrap());
+
+                    if schema_then_.is_some() {
+                        let schema_then = schema_then_.unwrap();
+                        let then_path = [path, "then"].join("/");
+                        state.append(schema_then.validate_in(val, then_path.as_ref()));
+                    } else {
+                        state.missing.push(self.then_.as_ref().unwrap().clone());
+                    }
+                }
+            } else if self.else_.is_some() {
+                let schema_else_ = scope.resolve(&self.else_.as_ref().unwrap());
+
+                if schema_else_.is_some() {
+                    let schema_else = schema_else_.unwrap();
+                    let else_path = [path, "else"].join("/");
+                    state.append(schema_else.validate_in(val, else_path.as_ref()));
+                } else {
+                    state.missing.push(self.else_.as_ref().unwrap().clone());
+                }
+            }
+        } else {
+            state.missing.push(self.if_.clone());
+        }
+        state
+    }
+}

--- a/src/json_schema/validators/content_media.rs
+++ b/src/json_schema/validators/content_media.rs
@@ -12,7 +12,7 @@ pub struct ContentMedia {
 }
 
 impl super::Validator for ContentMedia {
-    fn validate(&self, val: &Value, path: &str, scope: &scope::Scope) -> super::ValidationState {
+    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
         let decoded_val = if self.encoding.is_some() && val.is_string() {
             let v = self
                 .encoding

--- a/src/json_schema/validators/content_media.rs
+++ b/src/json_schema/validators/content_media.rs
@@ -1,0 +1,55 @@
+use serde_json::Value;
+
+use super::super::errors;
+use super::super::scope;
+
+use super::super::keywords::content_media::{ContentEncoding, ContentMediaType};
+
+#[allow(missing_copy_implementations)]
+pub struct ContentMedia {
+    pub type_: Option<ContentMediaType>,
+    pub encoding: Option<ContentEncoding>,
+}
+
+impl super::Validator for ContentMedia {
+    fn validate(&self, val: &Value, path: &str, scope: &scope::Scope) -> super::ValidationState {
+        let decoded_val = if self.encoding.is_some() && val.is_string() {
+            let v = self
+                .encoding
+                .as_ref()
+                .unwrap()
+                .decode_val(val.as_str().unwrap());
+            if v.is_err() {
+                return val_error!(errors::Format {
+                    path: path.to_string(),
+                    detail: v.err().unwrap(),
+                });
+            }
+            Some(Value::String(v.ok().unwrap()))
+        } else {
+            None
+        };
+
+        let val_ = if decoded_val.is_some() {
+            decoded_val.as_ref().unwrap()
+        } else {
+            val
+        };
+
+        if self.type_.is_some() && val_.is_string() {
+            if !self
+                .type_
+                .as_ref()
+                .unwrap()
+                .validate(val_.as_str().unwrap())
+            {
+                return val_error!(errors::Format {
+                    path: path.to_string(),
+                    detail: "".to_string(),
+                });
+            }
+        }
+
+        super::ValidationState::new()
+    }
+}

--- a/src/json_schema/validators/formats.rs
+++ b/src/json_schema/validators/formats.rs
@@ -9,6 +9,23 @@ use super::super::errors;
 use super::super::scope;
 
 #[allow(missing_copy_implementations)]
+pub struct Date;
+
+impl super::Validator for Date {
+    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+        let string = nonstrict_process!(val.as_str(), path);
+
+        match chrono::NaiveDate::parse_from_str(string, "%Y-%m-%d") {
+            Ok(_) => super::ValidationState::new(),
+            Err(_) => val_error!(errors::Format {
+                path: path.to_string(),
+                detail: "Malformed date".to_string()
+            }),
+        }
+    }
+}
+
+#[allow(missing_copy_implementations)]
 pub struct DateTime;
 
 impl super::Validator for DateTime {
@@ -88,6 +105,23 @@ impl super::Validator for Ipv6 {
             Err(_) => val_error!(errors::Format {
                 path: path.to_string(),
                 detail: "Malformed IP address".to_string()
+            }),
+        }
+    }
+}
+
+#[allow(missing_copy_implementations)]
+pub struct Time;
+
+impl super::Validator for Time {
+    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+        let string = nonstrict_process!(val.as_str(), path);
+
+        match chrono::NaiveTime::parse_from_str(string, "%H:%M:%S%.f%:z") {
+            Ok(_) => super::ValidationState::new(),
+            Err(_) => val_error!(errors::Format {
+                path: path.to_string(),
+                detail: "Malformed time".to_string()
             }),
         }
     }

--- a/src/json_schema/validators/formats.rs
+++ b/src/json_schema/validators/formats.rs
@@ -1,4 +1,5 @@
 use chrono;
+use json_pointer;
 use publicsuffix::List;
 use serde_json::Value;
 use std::net;
@@ -105,6 +106,23 @@ impl super::Validator for Ipv6 {
             Err(_) => val_error!(errors::Format {
                 path: path.to_string(),
                 detail: "Malformed IP address".to_string()
+            }),
+        }
+    }
+}
+
+#[allow(missing_copy_implementations)]
+pub struct JsonPointer;
+
+impl super::Validator for JsonPointer {
+    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+        let string = nonstrict_process!(val.as_str(), path);
+
+        match string.parse::<json_pointer::JsonPointer<_, _>>() {
+            Ok(_) => super::ValidationState::new(),
+            Err(_) => val_error!(errors::Format {
+                path: path.to_string(),
+                detail: "Malformed JSON pointer".to_string()
             }),
         }
     }

--- a/src/json_schema/validators/formats.rs
+++ b/src/json_schema/validators/formats.rs
@@ -71,7 +71,7 @@ impl super::Validator for Hostname {
             Ok(_) => super::ValidationState::new(),
             Err(_) => val_error!(errors::Format {
                 path: path.to_string(),
-                detail: "Malformed email address".to_string()
+                detail: "Malformed hostname".to_string()
             }),
         }
     }

--- a/src/json_schema/validators/formats.rs
+++ b/src/json_schema/validators/formats.rs
@@ -3,6 +3,7 @@ use json_pointer;
 use publicsuffix::List;
 use serde_json::Value;
 use std::net;
+use uritemplate;
 use url;
 use uuid;
 
@@ -112,6 +113,42 @@ impl super::Validator for Ipv6 {
 }
 
 #[allow(missing_copy_implementations)]
+pub struct IRI;
+
+impl super::Validator for IRI {
+    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+        let string = nonstrict_process!(val.as_str(), path);
+
+        match url::Url::parse(string) {
+            Ok(_) => super::ValidationState::new(),
+            Err(err) => val_error!(errors::Format {
+                path: path.to_string(),
+                detail: format!("Malformed IRI: {}", err)
+            }),
+        }
+    }
+}
+
+#[allow(missing_copy_implementations)]
+pub struct IRIReference;
+
+impl super::Validator for IRIReference {
+    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+        let string = nonstrict_process!(val.as_str(), path);
+
+        let base_url = url::Url::parse("http://example.com/").unwrap();
+
+        match base_url.join(string) {
+            Ok(_) => super::ValidationState::new(),
+            Err(err) => val_error!(errors::Format {
+                path: path.to_string(),
+                detail: format!("Malformed IRI reference: {}", err)
+            }),
+        }
+    }
+}
+
+#[allow(missing_copy_implementations)]
 pub struct JsonPointer;
 
 impl super::Validator for JsonPointer {
@@ -129,13 +166,47 @@ impl super::Validator for JsonPointer {
 }
 
 #[allow(missing_copy_implementations)]
+pub struct Regex;
+
+impl super::Validator for Regex {
+    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+        let string = nonstrict_process!(val.as_str(), path);
+
+        match regex::Regex::new(string) {
+            Ok(_) => super::ValidationState::new(),
+            Err(_) => val_error!(errors::Format {
+                path: path.to_string(),
+                detail: "Malformed regex".to_string()
+            }),
+        }
+    }
+}
+
+#[allow(missing_copy_implementations)]
+pub struct RelativeJsonPointer;
+
+impl super::Validator for RelativeJsonPointer {
+    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+        let string = nonstrict_process!(val.as_str(), path);
+
+        match string.parse::<json_pointer::JsonPointer<_, _>>() {
+            Ok(_) => super::ValidationState::new(),
+            Err(_) => val_error!(errors::Format {
+                path: path.to_string(),
+                detail: "Malformed relative JSON pointer".to_string()
+            }),
+        }
+    }
+}
+
+#[allow(missing_copy_implementations)]
 pub struct Time;
 
 impl super::Validator for Time {
     fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
-        match chrono::NaiveTime::parse_from_str(string, "%H:%M:%S%.f%:z") {
+        match chrono::NaiveTime::parse_from_str(string, "%H:%M:%S%.f%Z") {
             Ok(_) => super::ValidationState::new(),
             Err(_) => val_error!(errors::Format {
                 path: path.to_string(),
@@ -195,5 +266,17 @@ impl super::Validator for UriReference {
                 detail: format!("Malformed URI reference: {}", err)
             }),
         }
+    }
+}
+
+#[allow(missing_copy_implementations)]
+pub struct UriTemplate;
+
+impl super::Validator for UriTemplate {
+    fn validate(&self, val: &Value, _path: &str, _scope: &scope::Scope) -> super::ValidationState {
+        let string = nonstrict_process!(val.as_str(), path);
+
+        let _ = uritemplate::UriTemplate::new(string);
+        super::ValidationState::new()
     }
 }

--- a/src/json_schema/validators/mod.rs
+++ b/src/json_schema/validators/mod.rs
@@ -43,6 +43,7 @@ macro_rules! val_error {
 pub use self::conditional::Conditional;
 pub use self::const_::Const;
 pub use self::contains::Contains;
+pub use self::content_media::ContentMedia;
 pub use self::dependencies::Dependencies;
 pub use self::enum_::Enum;
 pub use self::items::Items;
@@ -64,6 +65,7 @@ pub use self::unique_items::UniqueItems;
 mod conditional;
 mod const_;
 mod contains;
+pub mod content_media;
 pub mod dependencies;
 mod enum_;
 pub mod formats;

--- a/src/json_schema/validators/mod.rs
+++ b/src/json_schema/validators/mod.rs
@@ -40,6 +40,7 @@ macro_rules! val_error {
     };
 }
 
+pub use self::conditional::Conditional;
 pub use self::const_::Const;
 pub use self::contains::Contains;
 pub use self::dependencies::Dependencies;
@@ -60,6 +61,7 @@ pub use self::required::Required;
 pub use self::type_::Type;
 pub use self::unique_items::UniqueItems;
 
+mod conditional;
 mod const_;
 mod contains;
 pub mod dependencies;

--- a/tests/schema/mod.rs
+++ b/tests/schema/mod.rs
@@ -65,30 +65,37 @@ fn test_suite() {
                     "one supplementary Unicode code point is not long enough".to_string(),
                 ),
                 (
+                    // TODO implement remote schema download
                     "refRemote.json".to_string(),
                     "remote ref invalid".to_string(),
                 ),
                 (
+                    // TODO implement remote schema download
                     "refRemote.json".to_string(),
                     "remote fragment invalid".to_string(),
                 ),
                 (
+                    // TODO implement remote schema download
                     "refRemote.json".to_string(),
                     "ref within ref invalid".to_string(),
                 ),
                 (
+                    // TODO implement remote schema download
                     "refRemote.json".to_string(),
                     "changed scope ref invalid".to_string(),
                 ),
                 (
+                    // TODO implement remote schema download
                     "refRemote.json".to_string(),
                     "base URI change ref invalid".to_string(),
                 ),
                 (
+                    // TODO implement remote schema download
                     "refRemote.json".to_string(),
                     "string is invalid".to_string(),
                 ),
                 (
+                    // TODO implement remote schema download
                     "refRemote.json".to_string(),
                     "object is invalid".to_string(),
                 ),
@@ -101,11 +108,11 @@ fn test_suite() {
                     "a negative bignum is an integer".to_string(),
                 ),
                 (
-                    "format.json".to_string(),
+                    "uri-reference.json".to_string(),
                     "an invalid URI Reference".to_string(),
                 ),
                 (
-                    "format.json".to_string(),
+                    "uri-reference.json".to_string(),
                     "an invalid URI fragment".to_string(),
                 ),
                 (
@@ -121,37 +128,52 @@ fn test_suite() {
                     "latin-1 non-breaking-space matches (unlike e.g. Python)".to_string(),
                 ),
                 (
+                    // TODO handle these "empty" edge cases in json-pointer
                     "json-pointer.json".to_string(),
                     "not a valid JSON-pointer (URI Fragment Identifier) #1".to_string(),
                 ),
                 (
+                    // TODO handle these "empty" edge cases in json-pointer
                     "json-pointer.json".to_string(),
                     "not a valid JSON-pointer (URI Fragment Identifier) #2".to_string(),
                 ),
                 (
+                    // TODO handle these "empty" edge cases in json-pointer
                     "json-pointer.json".to_string(),
                     "not a valid JSON-pointer (URI Fragment Identifier) #3".to_string(),
                 ),
                 (
+                    // I believe it is trimmed as it is at the beginning, it works when inside.
                     "idn-hostname.json".to_string(),
                     "contains illegal char U+302E Hangul single dot tone mark".to_string(),
                 ),
                 (
+                    // TODO uritemplate needs fixes/changes but the maintainer is inactive.
                     "uri-template.json".to_string(),
                     "an invalid uri-template".to_string(),
                 ),
-                ("time.json".to_string(), "a valid time string".to_string()),
-                ("ref.json".to_string(), "remote ref invalid".to_string()),
+                (
+                    // https://github.com/chronotope/chrono/issues/288
+                    "time.json".to_string(),
+                    "a valid time string".to_string(),
+                ),
+                (
+                    // TODO implement remote schema download
+                    "ref.json".to_string(),
+                    "remote ref invalid".to_string(),
+                ),
+                (
+                    // same as URI
+                    "iri-reference.json".to_string(),
+                    "an invalid IRI Reference".to_string(),
+                ),
+                (
+                    // same as URI
+                    "iri-reference.json".to_string(),
+                    "an invalid IRI fragment".to_string(),
+                ),
             ];
             let group_exceptions: Vec<(String, String)> = vec![
-                (
-                    "format.json".to_string(),
-                    "validation of JSON-pointers (JSON String Representation)".to_string(),
-                ),
-                (
-                    "format.json".to_string(),
-                    "format: uri-template".to_string(),
-                ),
                 (
                     "ecmascript-regex.json".to_string(),
                     "ECMA 262 regex escapes control codes with \\c and upper letter".to_string(),
@@ -177,19 +199,12 @@ fn test_suite() {
                     "ECMA 262 \\w matches everything but ascii letters".to_string(),
                 ),
                 (
-                    "iri-reference.json".to_string(),
-                    "validation of IRI References".to_string(),
-                ),
-                ("iri.json".to_string(), "validation of IRIs".to_string()),
-                (
-                    "uri-reference.json".to_string(),
-                    "validation of URI References".to_string(),
-                ),
-                (
+                    // TODO json-pointer needs to handle relative JSON pointers
                     "relative-json-pointer.json".to_string(),
                     "validation of Relative JSON Pointers (RJP)".to_string(),
                 ),
                 (
+                    // TODO implement remote schema download
                     "definitions.json".to_string(),
                     "invalid definition".to_string(),
                 ),
@@ -246,6 +261,7 @@ fn test_suite() {
 
                     let state = schema.validate(&data);
 
+                    // TODO implement remote schema download for strict validation
                     if state.is_valid() != valid {
                         panic!(
                             "Failure: \"{}\" in \"{}\" -> \"{}\" with state: \n {}",

--- a/tests/schema/mod.rs
+++ b/tests/schema/mod.rs
@@ -177,18 +177,6 @@ fn test_suite() {
                     "ECMA 262 \\w matches everything but ascii letters".to_string(),
                 ),
                 (
-                    "content.json".to_string(),
-                    "validation of string-encoded content based on media type".to_string(),
-                ),
-                (
-                    "content.json".to_string(),
-                    "validation of binary string-encoding".to_string(),
-                ),
-                (
-                    "content.json".to_string(),
-                    "validation of binary-encoded media type documents".to_string(),
-                ),
-                (
                     "iri-reference.json".to_string(),
                     "validation of IRI References".to_string(),
                 ),

--- a/tests/schema/mod.rs
+++ b/tests/schema/mod.rs
@@ -42,12 +42,22 @@ fn test_suite() {
         .ok()
         .unwrap();
 
-    let json_v6_schema: Value = from_str(&content).unwrap();
+    let json_v7_schema: Value = from_str(&content).unwrap();
+
+    println!("test json_schema::test_suite");
 
     visit_specs(
         &path::Path::new("tests/schema/JSON-Schema-Test-Suite/tests/draft7"),
         |path, spec_set: Value| {
             let spec_set = spec_set.as_array().unwrap();
+
+            println!(
+                "\t{}",
+                path.file_name()
+                    .unwrap_or_default()
+                    .to_str()
+                    .unwrap_or_default()
+            );
 
             let exceptions: Vec<(String, String)> = vec![
                 (
@@ -126,6 +136,12 @@ fn test_suite() {
                     "idn-hostname.json".to_string(),
                     "contains illegal char U+302E Hangul single dot tone mark".to_string(),
                 ),
+                (
+                    "uri-template.json".to_string(),
+                    "an invalid uri-template".to_string(),
+                ),
+                ("time.json".to_string(), "a valid time string".to_string()),
+                ("ref.json".to_string(), "remote ref invalid".to_string()),
             ];
             let group_exceptions: Vec<(String, String)> = vec![
                 (
@@ -160,13 +176,42 @@ fn test_suite() {
                     "ecmascript-regex.json".to_string(),
                     "ECMA 262 \\w matches everything but ascii letters".to_string(),
                 ),
+                (
+                    "content.json".to_string(),
+                    "validation of string-encoded content based on media type".to_string(),
+                ),
+                (
+                    "content.json".to_string(),
+                    "validation of binary string-encoding".to_string(),
+                ),
+                (
+                    "content.json".to_string(),
+                    "validation of binary-encoded media type documents".to_string(),
+                ),
+                (
+                    "iri-reference.json".to_string(),
+                    "validation of IRI References".to_string(),
+                ),
+                ("iri.json".to_string(), "validation of IRIs".to_string()),
+                (
+                    "uri-reference.json".to_string(),
+                    "validation of URI References".to_string(),
+                ),
+                (
+                    "relative-json-pointer.json".to_string(),
+                    "validation of Relative JSON Pointers (RJP)".to_string(),
+                ),
+                (
+                    "definitions.json".to_string(),
+                    "invalid definition".to_string(),
+                ),
             ];
 
             for spec in spec_set.iter() {
                 let spec = spec.as_object().unwrap();
                 let mut scope = json_schema::Scope::new();
 
-                scope.compile(json_v6_schema.clone(), true).ok().unwrap();
+                scope.compile(json_v7_schema.clone(), true).ok().unwrap();
 
                 let spec_desc = spec
                     .get("description")
@@ -177,8 +222,10 @@ fn test_suite() {
                     spec_desc.to_string(),
                 ));
                 if spec_exception_found {
-                    println!("test json_schema::test_suite -> {} .. skipped", spec_desc);
+                    println!("\t\t{} .. skipped", spec_desc);
                     continue;
+                } else {
+                    println!("\t\t{}", spec_desc);
                 }
 
                 let schema =
@@ -205,10 +252,7 @@ fn test_suite() {
                         description.to_string(),
                     ));
                     if exception_found {
-                        println!(
-                            "test json_schema::test_suite -> {} -> {} .. skipped",
-                            spec_desc, description
-                        );
+                        println!("\t\t\t{} .. skipped", description);
                         continue;
                     }
 
@@ -223,10 +267,7 @@ fn test_suite() {
                             to_string_pretty(&to_value(&state).unwrap()).unwrap()
                         )
                     } else {
-                        println!(
-                            "test json_schema::test_suite -> {} -> {} .. ok",
-                            spec_desc, description
-                        );
+                        println!("\t\t\t{} .. ok", description);
                     }
                 }
             }

--- a/tests/schema/mod.rs
+++ b/tests/schema/mod.rs
@@ -45,7 +45,7 @@ fn test_suite() {
     let json_v6_schema: Value = from_str(&content).unwrap();
 
     visit_specs(
-        &path::Path::new("tests/schema/JSON-Schema-Test-Suite/tests/draft6"),
+        &path::Path::new("tests/schema/JSON-Schema-Test-Suite/tests/draft7"),
         |path, spec_set: Value| {
             let spec_set = spec_set.as_array().unwrap();
 

--- a/tests/schema/mod.rs
+++ b/tests/schema/mod.rs
@@ -122,6 +122,10 @@ fn test_suite() {
                     "json-pointer.json".to_string(),
                     "not a valid JSON-pointer (URI Fragment Identifier) #3".to_string(),
                 ),
+                (
+                    "idn-hostname.json".to_string(),
+                    "contains illegal char U+302E Hangul single dot tone mark".to_string(),
+                ),
             ];
             let group_exceptions: Vec<(String, String)> = vec![
                 (

--- a/tests/schema/mod.rs
+++ b/tests/schema/mod.rs
@@ -110,6 +110,18 @@ fn test_suite() {
                     "ecmascript-regex.json".to_string(),
                     "latin-1 non-breaking-space matches (unlike e.g. Python)".to_string(),
                 ),
+                (
+                    "json-pointer.json".to_string(),
+                    "not a valid JSON-pointer (URI Fragment Identifier) #1".to_string(),
+                ),
+                (
+                    "json-pointer.json".to_string(),
+                    "not a valid JSON-pointer (URI Fragment Identifier) #2".to_string(),
+                ),
+                (
+                    "json-pointer.json".to_string(),
+                    "not a valid JSON-pointer (URI Fragment Identifier) #3".to_string(),
+                ),
             ];
             let group_exceptions: Vec<(String, String)> = vec![
                 (


### PR DESCRIPTION
Closes #32.

Here's my attempt to support draft 7. It has limitations, most notably:
- `contentMediaType` and `contentEncoding` only support `application/json` and `base64` but I wanted to get some feedback on my implementation -- maybe that can be addressed in the future;
- the lack of support for remote refs/schemas, but this is already a current gap in Valico, and I propose to address it separately;
- the `time` format doesn't really conform to the standard because of https://github.com/chronotope/chrono/issues/288;
- https://github.com/remexre/json-pointer doesn't support relative pointers... yet;
- https://github.com/chowdhurya/rust-uritemplate needs better error handling; and
- the are keywords listed on https://json-schema.org/draft-07/json-schema-release-notes.html that don't seem to be covered by the official test suite -- I can look into it.

That's quite a few, but I am raising this PR for feedback and visibility.

PS: I just realised I have been only focusing on the validator part, not the DSL.