### PR TITLE
feat(json_schema): include unallowed additional property name in error detail

### DIFF
--- a/src/json_schema/validators/properties.rs
+++ b/src/json_schema/validators/properties.rs
@@ -62,7 +62,7 @@ impl super::Validator for Properties {
                 AdditionalKind::Boolean(allowed) if !allowed => {
                     state.errors.push(Box::new(errors::Properties {
                         path: path.to_string(),
-                        detail: "Additional properties are not allowed".to_string(),
+                        detail: format!("Additional property '{}' is not allowed", key)
                     }))
                 }
                 AdditionalKind::Schema(ref url) => {


### PR DESCRIPTION
Include the name of the unallowed property name in the errors::Properties details, enabling users to more precisely pin-point the issue in the JSON document.

The previous error required users to go back to the schema to know how to fix their JSON documents. Alternatively, the error's `path` could be changed to include the `key`, but that would potentially break backwards compatibility.