### PR TITLE
Fix time tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ uuid = {version = "0.8", features = ["v4"]}
 phf = "0.8"
 serde = "1"
 serde_json = "1"
-chrono = "0.4.6"
+chrono = "0.4.16"
 addr = "0.11"
 percent-encoding = "2.1"
 json-pointer = "0.3"

--- a/src/json_schema/validators/formats.rs
+++ b/src/json_schema/validators/formats.rs
@@ -216,7 +216,7 @@ impl super::Validator for Time {
     fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
-        match chrono::NaiveTime::parse_from_str(string, "%H:%M:%S%.f%Z") {
+        match chrono::NaiveTime::parse_from_str(string, "%H:%M:%S%.f") {
             Ok(_) => super::ValidationState::new(),
             Err(_) => val_error!(errors::Format {
                 path: path.to_string(),


### PR DESCRIPTION
In https://github.com/chronotope/chrono/pull/473, chrono changed how %Z is handled, and was changed to simply skip over any non-whitespace characters in the timezone section, just like glibc's `strptime`.

I'm not sure if this is the right fix, but it gets the tests to pass.