### PR TITLE
fix(json_schema): Replace deprecated function url::Url::into_string()

### DIFF
--- a/src/json_schema/helpers.rs
+++ b/src/json_schema/helpers.rs
@@ -96,7 +96,7 @@ pub fn alter_fragment_path(mut url: Url, new_fragment: String) -> Url {
 pub fn serialize_schema_path(url: &Url) -> (String, Option<String>) {
     let mut url_without_fragment = url.clone();
     url_without_fragment.set_fragment(None);
-    let mut url_str = url_without_fragment.into_string();
+    let mut url_str: String = url_without_fragment.into();
 
     match url.fragment().as_ref() {
         Some(fragment) if !fragment.is_empty() => {

--- a/src/json_schema/schema.rs
+++ b/src/json_schema/schema.rs
@@ -452,7 +452,7 @@ impl Schema {
         if id.is_some() {
             context
                 .scopes
-                .insert(id.clone().unwrap().into_string(), context.fragment.clone());
+                .insert(id.clone().unwrap().into(), context.fragment.clone());
         }
 
         let validators = if is_schema && def.is_object() {


### PR DESCRIPTION
This fixes two compilation warnings due to using deprecated functions.