### PR TITLE
remove oldtime from chrono features because of RUSTSEC-2020-0071

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ uuid = {version = "0.8", features = ["v4"]}
 phf = "0.8"
 serde = "1"
 serde_json = "1"
-chrono = "0.4.6"
+chrono = { version = "0.4.6", default-features = false, features = ["clock", "std"] }
 addr = "0.11"
 percent-encoding = "2.1"
 json-pointer = "0.3"


### PR DESCRIPTION
valico does not seem to be using any of the chrono oldtime feature bits
so let's disable it to not bring in the time crate and not be vulnerable
to RUSTSEC-2020-0071.

Right now, chrono does not support time >= 0.2 which is not vulnerable
to the stated issue. Once it does, valico might get a dependency version
dump for chrono and this patch can be reverted.