### PR TITLE
Initial draft2019-09 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,23 @@ jobs:
 
       - name: Run tests
         run: cargo test --verbose
+
+  docs:
+    name: docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check docs
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --no-deps --document-private-items --workspace
+
+  rustfmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,12 @@ jobs:
 
       - name: Check formatting
         run: cargo fmt --all -- --check
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Check clippy lints
+        run: cargo clippy --all --tests --workspace -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: Rust
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Build
+        run: cargo build --verbose
+
+      - name: Run tests
+        run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ uuid = {version = "0.8", features = ["v4"]}
 phf = "0.8"
 serde = "1"
 serde_json = "1"
-chrono = "0.4.6"
+chrono = "0.4.16"
 addr = "0.11"
 percent-encoding = "2.1"
 json-pointer = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,18 +15,18 @@ regex = "1"
 url = "2"
 jsonway = "2.0"
 uuid = {version = "0.8", features = ["v4"]}
-phf = "0.8"
+phf = "0.10"
 serde = "1"
 serde_json = "1"
 chrono = "0.4.16"
-addr = "0.11"
+addr = "0.15.2"
 percent-encoding = "2.1"
 json-pointer = "0.3"
 uritemplate-next = "0.2"
 base64 = "0.13"
 
 [build-dependencies.phf_codegen]
-version = "0.8"
+version = "0.10"
 
 [[test]]
 name = "tests"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ build = "build.rs"
 edition = "2018"
 
 [dependencies]
-regex = "1"
+fancy-regex = "0.8"
 url = "2"
 jsonway = "2.0"
 uuid = {version = "0.8", features = ["v4"]}

--- a/build.rs
+++ b/build.rs
@@ -34,6 +34,8 @@ fn main() {
             .entry("anyOf")
             .entry("allOf")
             .entry("oneOf")
+            .entry("const")
+            .entry("enum")
             .build()
     )
     .unwrap();

--- a/build.rs
+++ b/build.rs
@@ -27,6 +27,8 @@ fn main() {
             .entry("properties")
             .entry("patternProperties")
             .entry("dependencies")
+            .entry("dependentSchemas")
+            .entry("dependentRequired")
             .entry("definitions")
             .entry("$defs")
             .entry("anyOf")

--- a/build.rs
+++ b/build.rs
@@ -71,6 +71,7 @@ fn main() {
             .entry("$defs")
             .entry("$schema")
             .entry("$id")
+            .entry("$anchor")
             .entry("default")
             .entry("title")
             .entry("description")

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,7 @@ fn main() {
     let path = Path::new(&env::var("OUT_DIR").unwrap()).join("codegen.rs");
     let mut file = BufWriter::new(File::create(&path).unwrap());
 
-    write!(&mut file, "#[allow(clippy::unreadable_literal)]\n").unwrap();
+    writeln!(&mut file, "#[allow(clippy::unreadable_literal)]").unwrap();
     write!(
         &mut file,
         "static PROPERTY_KEYS: phf::Set<&'static str> = {}",
@@ -17,9 +17,9 @@ fn main() {
             .build()
     )
     .unwrap();
-    write!(&mut file, ";\n").unwrap();
+    writeln!(&mut file, ";").unwrap();
 
-    write!(&mut file, "#[allow(clippy::unreadable_literal)]\n").unwrap();
+    writeln!(&mut file, "#[allow(clippy::unreadable_literal)]").unwrap();
     write!(
         &mut file,
         "static NON_SCHEMA_KEYS: phf::Set<&'static str> = {};",
@@ -35,7 +35,7 @@ fn main() {
     )
     .unwrap();
 
-    write!(&mut file, "#[allow(clippy::unreadable_literal)]\n").unwrap();
+    writeln!(&mut file, "#[allow(clippy::unreadable_literal)]").unwrap();
     write!(
         &mut file,
         "static BOOLEAN_SCHEMA_ARRAY_KEYS: phf::Set<&'static str> = {};",
@@ -48,7 +48,7 @@ fn main() {
     )
     .unwrap();
 
-    write!(&mut file, "#[allow(clippy::unreadable_literal)]\n").unwrap();
+    writeln!(&mut file, "#[allow(clippy::unreadable_literal)]").unwrap();
     write!(
         &mut file,
         "static FINAL_KEYS: phf::Set<&'static str> = {};",
@@ -61,7 +61,7 @@ fn main() {
     )
     .unwrap();
 
-    write!(&mut file, "#[allow(clippy::unreadable_literal)]\n").unwrap();
+    writeln!(&mut file, "#[allow(clippy::unreadable_literal)]").unwrap();
     write!(
         &mut file,
         "const ALLOW_NON_CONSUMED_KEYS: phf::Set<&'static str> = {};",

--- a/build.rs
+++ b/build.rs
@@ -28,6 +28,7 @@ fn main() {
             .entry("patternProperties")
             .entry("dependencies")
             .entry("definitions")
+            .entry("$defs")
             .entry("anyOf")
             .entry("allOf")
             .entry("oneOf")
@@ -67,6 +68,7 @@ fn main() {
         "const ALLOW_NON_CONSUMED_KEYS: phf::Set<&'static str> = {};",
         phf_codegen::Set::new()
             .entry("definitions")
+            .entry("$defs")
             .entry("$schema")
             .entry("$id")
             .entry("default")

--- a/src/json_dsl/builder.rs
+++ b/src/json_dsl/builder.rs
@@ -217,7 +217,7 @@ impl Builder {
             state
         };
 
-        let path = if path == "" { "/" } else { path };
+        let path = if path.is_empty() { "/" } else { path };
 
         if let Some(ref id) = self.schema_id {
             if let Some(scope) = scope {
@@ -275,7 +275,7 @@ impl Builder {
             }
         }
 
-        let path = if path == "" { "/" } else { path };
+        let path = if path.is_empty() { "/" } else { path };
 
         for validator in self.validators.iter() {
             match validator.validate(val, path) {

--- a/src/json_dsl/builder.rs
+++ b/src/json_dsl/builder.rs
@@ -1,6 +1,5 @@
 use serde_json::{to_value, Value};
 
-
 use super::super::json_schema;
 use super::coercers;
 use super::errors;

--- a/src/json_dsl/coercers.rs
+++ b/src/json_dsl/coercers.rs
@@ -195,7 +195,7 @@ impl Coercer for NullCoercer {
             Ok(None)
         } else if val.is_string() {
             let val = val.as_str().unwrap();
-            if val == "" {
+            if val.is_empty() {
                 Ok(Some(json!(null)))
             } else {
                 Err(vec![Box::new(errors::WrongType {

--- a/src/json_dsl/mod.rs
+++ b/src/json_dsl/mod.rs
@@ -79,6 +79,7 @@ impl<T> ExtendedResult<T> {
                 errors,
                 missing: vec![],
                 replacement: None,
+                evaluated: Default::default(),
             },
         }
     }

--- a/src/json_dsl/param.rs
+++ b/src/json_dsl/param.rs
@@ -101,7 +101,7 @@ impl Param {
 
     pub fn nest<F>(&mut self, nest_def: F)
     where
-        F: FnOnce(&mut builder::Builder) -> (),
+        F: FnOnce(&mut builder::Builder),
     {
         self.nest = Some(builder::Builder::build(nest_def));
     }

--- a/src/json_dsl/param.rs
+++ b/src/json_dsl/param.rs
@@ -110,7 +110,7 @@ impl Param {
         self.allow_null = true;
     }
 
-    pub fn regex(&mut self, regex: regex::Regex) {
+    pub fn regex(&mut self, regex: fancy_regex::Regex) {
         self.validators.push(Box::new(regex));
     }
 

--- a/src/json_dsl/param.rs
+++ b/src/json_dsl/param.rs
@@ -1,7 +1,5 @@
-
 use serde::Serialize;
 use serde_json::{to_value, Value};
-
 
 use super::super::json_schema;
 use super::builder;

--- a/src/json_dsl/validators/regex.rs
+++ b/src/json_dsl/validators/regex.rs
@@ -1,4 +1,3 @@
-
 use serde_json::Value;
 
 use super::super::errors;

--- a/src/json_dsl/validators/regex.rs
+++ b/src/json_dsl/validators/regex.rs
@@ -2,17 +2,20 @@ use serde_json::Value;
 
 use super::super::errors;
 
-impl super::Validator for regex::Regex {
+impl super::Validator for fancy_regex::Regex {
     fn validate(&self, val: &Value, path: &str) -> super::ValidatorResult {
         let string = strict_process!(val.as_str(), path, "The value must be a string");
 
-        if self.is_match(string) {
-            Ok(())
-        } else {
-            Err(vec![Box::new(errors::WrongValue {
+        match self.is_match(string) {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(vec![Box::new(errors::WrongValue {
                 path: path.to_string(),
                 detail: Some("Value is not matched by required pattern".to_string()),
-            })])
+            })]),
+            Err(e) => Err(vec![Box::new(errors::WrongValue {
+                path: path.to_string(),
+                detail: Some(format!("Error evaluating regex '{}': {}", self, e)),
+            })]),
         }
     }
 }

--- a/src/json_schema/builder.rs
+++ b/src/json_schema/builder.rs
@@ -1,4 +1,3 @@
-
 use serde::{Serialize, Serializer};
 use serde_json::value::{to_value, Value};
 use std::collections;

--- a/src/json_schema/errors.rs
+++ b/src/json_schema/errors.rs
@@ -227,3 +227,12 @@ pub struct Format {
 }
 impl_err!(Format, "format", "Format is wrong", +detail);
 impl_serialize!(Format);
+
+#[derive(Debug)]
+#[allow(missing_copy_implementations)]
+pub struct Unevaluated {
+    pub path: String,
+    pub detail: String,
+}
+impl_err!(Unevaluated, "unevaluated", "Unevaluated condition is not met", +detail);
+impl_serialize!(Unevaluated);

--- a/src/json_schema/errors.rs
+++ b/src/json_schema/errors.rs
@@ -189,6 +189,18 @@ impl_serialize!(Contains);
 
 #[derive(Debug)]
 #[allow(missing_copy_implementations)]
+pub struct ContainsMinMax {
+    pub path: String,
+}
+impl_err!(
+    ContainsMinMax,
+    "min_contains/max_contains",
+    "Contains minimum/maximum is not met"
+);
+impl_serialize!(ContainsMinMax);
+
+#[derive(Debug)]
+#[allow(missing_copy_implementations)]
 pub struct Not {
     pub path: String,
 }

--- a/src/json_schema/helpers.rs
+++ b/src/json_schema/helpers.rs
@@ -10,7 +10,7 @@ pub fn generate_id() -> Url {
     Url::parse(&format!("json-schema://{}", uuid)).unwrap()
 }
 
-/// http://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-07
+/// <http://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-07>
 pub fn encode(string: &str) -> String {
     const QUERY_SET: percent_encoding::AsciiSet = percent_encoding::CONTROLS
         .add(b' ')

--- a/src/json_schema/helpers.rs
+++ b/src/json_schema/helpers.rs
@@ -20,7 +20,7 @@ pub fn encode(string: &str) -> String {
         .add(b'>')
         .add(b'%');
     percent_encoding::percent_encode(
-        string.replace("~", "~0").replace("/", "~1").as_bytes(),
+        string.replace('~', "~0").replace('/', "~1").as_bytes(),
         &QUERY_SET,
     )
     .to_string()
@@ -66,20 +66,20 @@ pub fn parse_url_key_with_base(
 }
 
 pub fn alter_fragment_path(mut url: Url, new_fragment: String) -> Url {
-    let normalized_fragment = if new_fragment.starts_with('/') {
-        &new_fragment[1..]
+    let normalized_fragment = if let Some(prefix) = new_fragment.strip_prefix('/') {
+        prefix
     } else {
         new_fragment.as_ref()
     };
 
     let result_fragment = match url.fragment() {
-        Some(ref fragment) if !fragment.is_empty() => {
+        Some(fragment) if !fragment.is_empty() => {
             if !fragment.starts_with('/') {
                 let mut result_fragment = "".to_string();
                 let mut fragment_parts = fragment.split('/').map(|s| s.to_string());
-                result_fragment.push_str("#");
+                result_fragment.push('#');
                 result_fragment.push_str(fragment_parts.next().unwrap().as_ref());
-                result_fragment.push_str("/");
+                result_fragment.push('/');
                 result_fragment.push_str(normalized_fragment.as_ref());
                 result_fragment
             } else {
@@ -105,7 +105,7 @@ pub fn serialize_schema_path(url: &Url) -> (String, Option<String>) {
                     .split('/')
                     .map(|s| s.to_string())
                     .collect::<Vec<String>>();
-                url_str.push_str("#");
+                url_str.push('#');
                 url_str.push_str(fragment_parts[0].as_ref());
                 let fragment = if fragment_parts.len() > 1 {
                     Some("/".to_string() + fragment_parts[1..].join("/").as_ref())

--- a/src/json_schema/keywords/conditional.rs
+++ b/src/json_schema/keywords/conditional.rs
@@ -19,20 +19,18 @@ impl super::Keyword for Conditional {
                 ctx.url.clone(),
                 [ctx.escaped_fragment().as_ref(), "if"].join("/"),
             );
-            let then_ = match maybe_then {
-                Some(_) => Some(helpers::alter_fragment_path(
+            let then_ = maybe_then.map(|_| {
+                helpers::alter_fragment_path(
                     ctx.url.clone(),
                     [ctx.escaped_fragment().as_ref(), "then"].join("/"),
-                )),
-                None => None,
-            };
-            let else_ = match maybe_else {
-                Some(_) => Some(helpers::alter_fragment_path(
+                )
+            });
+            let else_ = maybe_else.map(|_| {
+                helpers::alter_fragment_path(
                     ctx.url.clone(),
                     [ctx.escaped_fragment().as_ref(), "else"].join("/"),
-                )),
-                None => None,
-            };
+                )
+            });
             Ok(Some(Box::new(validators::Conditional {
                 if_,
                 then_,
@@ -66,7 +64,7 @@ fn validate_if_then() {
         true,
     );
 
-    assert!(!schema.is_err(), schema.err().unwrap().to_string());
+    assert!(schema.is_ok(), "{}", schema.err().unwrap().to_string());
 
     let s = schema.unwrap();
     assert_eq!(s.validate(&to_value(3).unwrap()).is_valid(), true);
@@ -94,7 +92,7 @@ fn validate_if_then_else() {
         true,
     );
 
-    assert!(!schema.is_err(), schema.err().unwrap().to_string());
+    assert!(schema.is_ok(), "{}", schema.err().unwrap().to_string());
 
     let s = schema.unwrap();
     assert_eq!(s.validate(&to_value(3).unwrap()).is_valid(), true);

--- a/src/json_schema/keywords/content_media.rs
+++ b/src/json_schema/keywords/content_media.rs
@@ -13,13 +13,13 @@ pub enum ContentMediaType {
 impl ContentMediaType {
     pub fn as_str(&self) -> &str {
         match self {
-            &ContentMediaType::ApplicationJson => "application/json",
+            ContentMediaType::ApplicationJson => "application/json",
         }
     }
 
     pub fn validate(&self, val: &str) -> bool {
         match self {
-            &ContentMediaType::ApplicationJson => serde_json::from_str::<Value>(val),
+            ContentMediaType::ApplicationJson => serde_json::from_str::<Value>(val),
         }
         .is_ok()
     }
@@ -43,13 +43,13 @@ pub enum ContentEncoding {
 impl ContentEncoding {
     pub fn as_str(&self) -> &str {
         match self {
-            &ContentEncoding::Base64 => "base64",
+            ContentEncoding::Base64 => "base64",
         }
     }
 
     pub fn decode_val(&self, val: &str) -> Result<String, String> {
         match self {
-            &ContentEncoding::Base64 => match base64::decode(val) {
+            ContentEncoding::Base64 => match base64::decode(val) {
                 Ok(v) => match str::from_utf8(&v[..]) {
                     Ok(s) => Ok(s.to_string()),
                     Err(e) => Err(e.to_string()),
@@ -76,8 +76,7 @@ impl super::Keyword for ContentMedia {
     fn compile(&self, def: &Value, ctx: &schema::WalkContext<'_>) -> super::KeywordResult {
         let maybe_content_media_type = def.get("contentMediaType");
         let mut type_ = None;
-        if maybe_content_media_type.is_some() {
-            let content_media_type = maybe_content_media_type.unwrap();
+        if let Some(content_media_type) = maybe_content_media_type {
             if !content_media_type.is_string() {
                 return Err(schema::SchemaError::Malformed {
                     path: ctx.fragment.join("/"),
@@ -85,22 +84,21 @@ impl super::Keyword for ContentMedia {
                 });
             } else {
                 let media_type = content_media_type.as_str().unwrap().parse().ok();
-                if media_type.is_none() {
+                if let Some(media_type) = media_type {
+                    type_ = Some(media_type);
+                } else {
                     return Err(schema::SchemaError::Malformed {
                         path: ctx.fragment.join("/"),
                         detail: "contentMediaType MUST be one of [\"application/json\"]"
                             .to_string(),
                     });
-                } else {
-                    type_ = Some(media_type.unwrap());
                 }
             }
         }
 
         let maybe_content_encoding = def.get("contentEncoding");
         let mut encoding = None;
-        if maybe_content_encoding.is_some() {
-            let content_encoding = maybe_content_encoding.unwrap();
+        if let Some(content_encoding) = maybe_content_encoding {
             if !content_encoding.is_string() {
                 return Err(schema::SchemaError::Malformed {
                     path: ctx.fragment.join("/"),
@@ -108,13 +106,13 @@ impl super::Keyword for ContentMedia {
                 });
             } else {
                 let encoding_ = content_encoding.as_str().unwrap().parse().ok();
-                if encoding_.is_none() {
+                if let Some(encoding_) = encoding_ {
+                    encoding = Some(encoding_);
+                } else {
                     return Err(schema::SchemaError::Malformed {
                         path: ctx.fragment.join("/"),
                         detail: "contentEncoding MUST be one of [\"base64\"]".to_string(),
                     });
-                } else {
-                    encoding = Some(encoding_.unwrap());
                 }
             }
         }

--- a/src/json_schema/keywords/mod.rs
+++ b/src/json_schema/keywords/mod.rs
@@ -93,7 +93,10 @@ pub fn default() -> KeywordMap {
         &mut map,
     );
     decouple_keyword(
-        (vec!["dependencies"], Box::new(dependencies::Dependencies)),
+        (
+            vec!["dependencies", "dependentRequired", "dependentSchemas"],
+            Box::new(dependencies::Dependencies),
+        ),
         &mut map,
     );
     decouple_keyword((vec!["enum"], Box::new(enum_::Enum)), &mut map);

--- a/src/json_schema/keywords/mod.rs
+++ b/src/json_schema/keywords/mod.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use super::schema;
 use super::validators;
+use super::SchemaVersion;
 
 pub type KeywordResult = Result<Option<validators::BoxedValidator>, schema::SchemaError>;
 pub type KeywordPair = (Vec<&'static str>, Box<dyn Keyword + 'static>);
@@ -14,10 +15,13 @@ pub type KeywordMap = collections::HashMap<&'static str, Arc<KeywordConsumer>>;
 
 pub trait Keyword: Send + Sync + any::Any {
     fn compile(&self, def: &Value, ctx: &schema::WalkContext) -> KeywordResult;
-    fn is_exclusive(&self) -> bool {
+    fn is_exclusive(&self, _version: SchemaVersion) -> bool {
         false
     }
     fn place_first(&self) -> bool {
+        false
+    }
+    fn place_last(&self) -> bool {
         false
     }
 }
@@ -71,6 +75,7 @@ pub mod property_names;
 pub mod ref_;
 pub mod required;
 pub mod type_;
+mod unevaluated;
 pub mod unique_items;
 
 pub fn default() -> KeywordMap {
@@ -159,6 +164,13 @@ pub fn default() -> KeywordMap {
     );
     decouple_keyword((vec!["required"], Box::new(required::Required)), &mut map);
     decouple_keyword((vec!["type"], Box::new(type_::Type)), &mut map);
+    decouple_keyword(
+        (
+            vec!["unevaluatedItems"],
+            Box::new(unevaluated::UnevaluatedItems),
+        ),
+        &mut map,
+    );
     decouple_keyword(
         (vec!["uniqueItems"], Box::new(unique_items::UniqueItems)),
         &mut map,

--- a/src/json_schema/keywords/mod.rs
+++ b/src/json_schema/keywords/mod.rs
@@ -80,7 +80,13 @@ pub fn default() -> KeywordMap {
     decouple_keyword((vec!["allOf"], Box::new(of::AllOf)), &mut map);
     decouple_keyword((vec!["anyOf"], Box::new(of::AnyOf)), &mut map);
     decouple_keyword((vec!["const"], Box::new(const_::Const)), &mut map);
-    decouple_keyword((vec!["contains"], Box::new(contains::Contains)), &mut map);
+    decouple_keyword(
+        (
+            vec!["contains", "minContains", "maxContains"],
+            Box::new(contains::Contains),
+        ),
+        &mut map,
+    );
     decouple_keyword(
         (vec!["dependencies"], Box::new(dependencies::Dependencies)),
         &mut map,

--- a/src/json_schema/keywords/mod.rs
+++ b/src/json_schema/keywords/mod.rs
@@ -175,6 +175,14 @@ pub fn default() -> KeywordMap {
         &mut map,
     );
     decouple_keyword(
+        (
+            vec!["unevaluatedProperties"],
+            Box::new(unevaluated::UnevaluatedProperties),
+        ),
+        &mut map,
+    );
+
+    decouple_keyword(
         (vec!["uniqueItems"], Box::new(unique_items::UniqueItems)),
         &mut map,
     );

--- a/src/json_schema/keywords/of.rs
+++ b/src/json_schema/keywords/of.rs
@@ -43,7 +43,7 @@ macro_rules! of_keyword {
                         }
                     }
 
-                    Ok(Some(Box::new(validators::$name { schemes: schemes })))
+                    Ok(Some(Box::new(validators::$name { schemes })))
                 } else {
                     Err(schema::SchemaError::Malformed {
                         path: ctx.fragment.join("/"),

--- a/src/json_schema/keywords/of.rs
+++ b/src/json_schema/keywords/of.rs
@@ -157,7 +157,7 @@ fn conflicting_defaults() {
     let result = schema.validate(&json!({}));
     assert!(!result.is_valid());
     assert_eq!(&*format!("{:?}", result),
-      "ValidationState { errors: [WrongType { path: \"/a\", detail: \"The value must be number\" }], missing: [], replacement: None }");
+      "ValidationState { errors: [WrongType { path: \"/a\", detail: \"The value must be number\" }], missing: [], replacement: None, evaluated: {\"/a\"} }");
 }
 
 #[test]
@@ -188,10 +188,11 @@ fn divergent_defaults() {
             true,
         )
         .unwrap();
-    let result = schema.validate(&json!({}));
+    let mut result = schema.validate(&json!({}));
     assert!(!result.is_valid());
+    result.evaluated.clear();
     assert_eq!(&*format!("{:?}", result),
-      "ValidationState { errors: [DivergentDefaults { path: \"\" }], missing: [], replacement: None }");
+      "ValidationState { errors: [DivergentDefaults { path: \"\" }], missing: [], replacement: None, evaluated: {} }");
 }
 
 #[test]

--- a/src/json_schema/keywords/pattern.rs
+++ b/src/json_schema/keywords/pattern.rs
@@ -11,7 +11,7 @@ impl super::Keyword for Pattern {
 
         if pattern.is_string() {
             let pattern_val = pattern.as_str().unwrap();
-            match regex::Regex::new(pattern_val) {
+            match fancy_regex::Regex::new(pattern_val) {
                 Ok(re) => Ok(Some(Box::new(validators::Pattern { regex: re }))),
                 Err(err) => Err(schema::SchemaError::Malformed {
                     path: ctx.fragment.join("/"),

--- a/src/json_schema/keywords/properties.rs
+++ b/src/json_schema/keywords/properties.rs
@@ -69,7 +69,7 @@ impl super::Keyword for Properties {
                 });
             }
         } else {
-            validators::properties::AdditionalKind::Boolean(true)
+            validators::properties::AdditionalKind::Unspecified
         };
 
         let patterns = if let Some(pattern) = maybe_pattern {

--- a/src/json_schema/keywords/properties.rs
+++ b/src/json_schema/keywords/properties.rs
@@ -79,7 +79,7 @@ impl super::Keyword for Properties {
 
                 for (key, value) in pattern.iter() {
                     if value.is_object() || value.is_boolean() {
-                        match regex::Regex::new(key.as_ref()) {
+                        match fancy_regex::Regex::new(key.as_ref()) {
                             Ok(regex) => {
                                 let url = helpers::alter_fragment_path(ctx.url.clone(), [
                                     ctx.escaped_fragment().as_ref(),

--- a/src/json_schema/keywords/properties.rs
+++ b/src/json_schema/keywords/properties.rs
@@ -36,7 +36,13 @@ impl super::Keyword for Properties {
                         );
                     } else {
                         return Err(schema::SchemaError::Malformed {
-                            path: ctx.fragment.join("/"),
+                            path: ctx
+                                .fragment
+                                .iter()
+                                .map(String::as_str)
+                                .chain(["properties", key])
+                                .flat_map(|s| s.chars().chain(['/']))
+                                .collect(),
                             detail: "Each value of this object MUST be an object or a boolean"
                                 .to_string(),
                         });
@@ -97,7 +103,7 @@ impl super::Keyword for Properties {
                         }
                     } else {
                         return Err(schema::SchemaError::Malformed {
-                            path: ctx.fragment.join("/"),
+                            path: ctx.fragment.join("/") + "patternProperties",
                             detail: "Each value of this object MUST be an object or a boolean"
                                 .to_string(),
                         });

--- a/src/json_schema/keywords/ref_.rs
+++ b/src/json_schema/keywords/ref_.rs
@@ -1,6 +1,8 @@
 use serde_json::Value;
 use url::Url;
 
+use crate::json_schema::SchemaVersion;
+
 use super::super::schema;
 use super::super::validators;
 
@@ -29,8 +31,8 @@ impl super::Keyword for Ref {
         }
     }
 
-    fn is_exclusive(&self) -> bool {
-        true
+    fn is_exclusive(&self, version: SchemaVersion) -> bool {
+        version < SchemaVersion::Draft2019_09
     }
 }
 

--- a/src/json_schema/keywords/unevaluated.rs
+++ b/src/json_schema/keywords/unevaluated.rs
@@ -1,0 +1,42 @@
+use crate::json_schema::SchemaVersion;
+
+use super::super::helpers;
+use super::super::schema;
+use super::super::validators;
+use super::Keyword;
+
+pub struct UnevaluatedItems;
+impl Keyword for UnevaluatedItems {
+    fn compile(
+        &self,
+        def: &serde_json::Value,
+        ctx: &crate::json_schema::schema::WalkContext,
+    ) -> super::KeywordResult {
+        if ctx.version < SchemaVersion::Draft2019_09 {
+            return Ok(None);
+        }
+        let items = keyword_key_exists!(def, "unevaluatedItems");
+
+        let validator = match items {
+            serde_json::Value::Bool(bool) => validators::UnevaluatedItems::Bool(*bool),
+            serde_json::Value::Object(_) => {
+                validators::UnevaluatedItems::Schema(helpers::alter_fragment_path(
+                    ctx.url.clone(),
+                    [ctx.escaped_fragment().as_ref(), "unevaluatedItems"].join("/"),
+                ))
+            }
+            _ => {
+                return Err(schema::SchemaError::Malformed {
+                    path: ctx.fragment.join("/"),
+                    detail: "unevaluatedItems MUST be a bool or an object".to_string(),
+                })
+            }
+        };
+
+        Ok(Some(Box::new(validator)))
+    }
+
+    fn place_last(&self) -> bool {
+        true
+    }
+}

--- a/src/json_schema/keywords/unevaluated.rs
+++ b/src/json_schema/keywords/unevaluated.rs
@@ -18,17 +18,65 @@ impl Keyword for UnevaluatedItems {
         let items = keyword_key_exists!(def, "unevaluatedItems");
 
         let validator = match items {
-            serde_json::Value::Bool(bool) => validators::UnevaluatedItems::Bool(*bool),
-            serde_json::Value::Object(_) => {
-                validators::UnevaluatedItems::Schema(helpers::alter_fragment_path(
-                    ctx.url.clone(),
-                    [ctx.escaped_fragment().as_ref(), "unevaluatedItems"].join("/"),
-                ))
-            }
+            serde_json::Value::Bool(bool) => validators::Unevaluated {
+                is_items: true,
+                schema: validators::unevaluated::UnevaluatedSchema::Bool(*bool),
+            },
+            serde_json::Value::Object(_) => validators::Unevaluated {
+                is_items: true,
+                schema: validators::unevaluated::UnevaluatedSchema::Schema(
+                    helpers::alter_fragment_path(
+                        ctx.url.clone(),
+                        [ctx.escaped_fragment().as_ref(), "unevaluatedItems"].join("/"),
+                    ),
+                ),
+            },
             _ => {
                 return Err(schema::SchemaError::Malformed {
                     path: ctx.fragment.join("/"),
                     detail: "unevaluatedItems MUST be a bool or an object".to_string(),
+                })
+            }
+        };
+
+        Ok(Some(Box::new(validator)))
+    }
+
+    fn place_last(&self) -> bool {
+        true
+    }
+}
+
+pub struct UnevaluatedProperties;
+impl Keyword for UnevaluatedProperties {
+    fn compile(
+        &self,
+        def: &serde_json::Value,
+        ctx: &crate::json_schema::schema::WalkContext,
+    ) -> super::KeywordResult {
+        if ctx.version < SchemaVersion::Draft2019_09 {
+            return Ok(None);
+        }
+        let items = keyword_key_exists!(def, "unevaluatedProperties");
+
+        let validator = match items {
+            serde_json::Value::Bool(bool) => validators::Unevaluated {
+                is_items: false,
+                schema: validators::unevaluated::UnevaluatedSchema::Bool(*bool),
+            },
+            serde_json::Value::Object(_) => validators::Unevaluated {
+                is_items: false,
+                schema: validators::unevaluated::UnevaluatedSchema::Schema(
+                    helpers::alter_fragment_path(
+                        ctx.url.clone(),
+                        [ctx.escaped_fragment().as_ref(), "unevaluatedProperties"].join("/"),
+                    ),
+                ),
+            },
+            _ => {
+                return Err(schema::SchemaError::Malformed {
+                    path: ctx.fragment.join("/"),
+                    detail: "unevaluatedProperties MUST be a bool or an object".to_string(),
                 })
             }
         };

--- a/src/json_schema/mod.rs
+++ b/src/json_schema/mod.rs
@@ -16,7 +16,7 @@ pub use self::schema::{Schema, SchemaError};
 pub use self::scope::Scope;
 pub use self::validators::ValidationState;
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Ord, PartialOrd)]
 /// Represents the schema version to use.
 pub enum SchemaVersion {
     /// Use draft 7.

--- a/src/json_schema/mod.rs
+++ b/src/json_schema/mod.rs
@@ -16,6 +16,15 @@ pub use self::schema::{Schema, SchemaError};
 pub use self::scope::Scope;
 pub use self::validators::ValidationState;
 
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+/// Represents the schema version to use.
+pub enum SchemaVersion {
+    /// Use draft 7.
+    Draft7,
+    /// Use draft 2019-09.
+    Draft2019_09,
+}
+
 #[derive(Copy, Debug, Clone)]
 pub enum PrimitiveType {
     Array,

--- a/src/json_schema/schema.rs
+++ b/src/json_schema/schema.rs
@@ -299,7 +299,6 @@ impl Schema {
             }
             if default.len() == items.tree.len() {
                 self.unsafe_set_default(Some(default.into()));
-                return;
             }
         }
     }

--- a/src/json_schema/scope.rs
+++ b/src/json_schema/scope.rs
@@ -103,6 +103,7 @@ impl Scope {
     /// between these is UNDEFINED as well). Therefore, if one validator depends on the
     /// fact that a default value has been injected by processing another validator, then
     /// the result is UNDEFINED (with the exception stated in the previous sentence).
+    #[must_use]
     pub fn supply_defaults(self) -> Self {
         Scope {
             keywords: self.keywords,

--- a/src/json_schema/scope.rs
+++ b/src/json_schema/scope.rs
@@ -4,6 +4,7 @@ use std::collections;
 use super::helpers;
 use super::keywords;
 use super::schema;
+use super::SchemaVersion;
 
 #[allow(dead_code)]
 #[derive(Debug)]
@@ -11,34 +12,41 @@ pub struct Scope {
     keywords: keywords::KeywordMap,
     schemes: collections::HashMap<String, schema::Schema>,
     pub(crate) supply_defaults: bool,
+    schema_version: SchemaVersion,
 }
 
 #[allow(dead_code)]
 impl Scope {
     pub fn new() -> Scope {
-        let mut scope = Scope::without_formats();
+        let mut scope = Scope::without_formats(SchemaVersion::Draft7);
         scope.add_keyword(vec!["format"], keywords::format::Format::new());
         scope
     }
 
-    pub fn without_formats() -> Scope {
+    pub fn without_formats(version: SchemaVersion) -> Scope {
         Scope {
             keywords: keywords::default(),
             schemes: collections::HashMap::new(),
             supply_defaults: false,
+            schema_version: version,
         }
     }
 
-    pub fn with_formats<F>(build_formats: F) -> Scope
+    pub fn with_formats<F>(build_formats: F, version: SchemaVersion) -> Scope
     where
         F: FnOnce(&mut keywords::format::FormatBuilders),
     {
-        let mut scope = Scope::without_formats();
+        let mut scope = Scope::without_formats(version);
         scope.add_keyword(
             vec!["format"],
             keywords::format::Format::with(build_formats),
         );
         scope
+    }
+
+    pub fn set_version(mut self, version: SchemaVersion) -> Self {
+        self.schema_version = version;
+        self
     }
 
     /// ### use `default` values to compute an enriched version of the input
@@ -109,6 +117,7 @@ impl Scope {
             keywords: self.keywords,
             schemes: self.schemes,
             supply_defaults: true,
+            schema_version: SchemaVersion::Draft7,
         }
     }
 
@@ -120,7 +129,7 @@ impl Scope {
         let mut schema = schema::compile(
             def,
             None,
-            schema::CompilationSettings::new(&self.keywords, ban_unknown),
+            schema::CompilationSettings::new(&self.keywords, ban_unknown, self.schema_version),
         )?;
         let id = schema.id.clone().unwrap();
         if self.supply_defaults {
@@ -139,7 +148,7 @@ impl Scope {
         let mut schema = schema::compile(
             def,
             Some(id.clone()),
-            schema::CompilationSettings::new(&self.keywords, ban_unknown),
+            schema::CompilationSettings::new(&self.keywords, ban_unknown, self.schema_version),
         )?;
         if self.supply_defaults {
             schema.add_defaults(id, self);
@@ -155,7 +164,7 @@ impl Scope {
         let mut schema = schema::compile(
             def,
             None,
-            schema::CompilationSettings::new(&self.keywords, ban_unknown),
+            schema::CompilationSettings::new(&self.keywords, ban_unknown, self.schema_version),
         )?;
         let id = schema.id.clone().unwrap();
         if self.supply_defaults {
@@ -173,7 +182,7 @@ impl Scope {
         let mut schema = schema::compile(
             def,
             Some(id.clone()),
-            schema::CompilationSettings::new(&self.keywords, ban_unknown),
+            schema::CompilationSettings::new(&self.keywords, ban_unknown, self.schema_version),
         )?;
         if self.supply_defaults {
             schema.add_defaults(id, self);

--- a/src/json_schema/validators/conditional.rs
+++ b/src/json_schema/validators/conditional.rs
@@ -15,17 +15,14 @@ impl super::Validator for Conditional {
         let mut state = super::ValidationState::new();
 
         let schema_if_ = scope.resolve(&self.if_);
-        if schema_if_.is_some() {
-            let schema_if = schema_if_.unwrap();
-
+        if let Some(schema_if) = schema_if_ {
             // TODO should the validation be strict?
             let if_path = [path, "if"].join("/");
             if schema_if.validate_in(val, if_path.as_ref()).is_valid() {
                 if self.then_.is_some() {
-                    let schema_then_ = scope.resolve(&self.then_.as_ref().unwrap());
+                    let schema_then_ = scope.resolve(self.then_.as_ref().unwrap());
 
-                    if schema_then_.is_some() {
-                        let schema_then = schema_then_.unwrap();
+                    if let Some(schema_then) = schema_then_ {
                         let then_path = [path, "then"].join("/");
                         state.append(schema_then.validate_in(val, then_path.as_ref()));
                     } else {
@@ -33,10 +30,9 @@ impl super::Validator for Conditional {
                     }
                 }
             } else if self.else_.is_some() {
-                let schema_else_ = scope.resolve(&self.else_.as_ref().unwrap());
+                let schema_else_ = scope.resolve(self.else_.as_ref().unwrap());
 
-                if schema_else_.is_some() {
-                    let schema_else = schema_else_.unwrap();
+                if let Some(schema_else) = schema_else_ {
                     let else_path = [path, "else"].join("/");
                     state.append(schema_else.validate_in(val, else_path.as_ref()));
                 } else {

--- a/src/json_schema/validators/conditional.rs
+++ b/src/json_schema/validators/conditional.rs
@@ -23,8 +23,9 @@ impl super::Validator for Conditional {
         let schema_if_ = scope.resolve(&self.if_);
         if let Some(schema_if) = schema_if_ {
             // TODO should the validation be strict?
-            let if_path = [path, "if"].join("/");
-            if schema_if.validate_in(val, if_path.as_ref()).is_valid() {
+            let if_state = schema_if.validate_in(val, path);
+            if if_state.is_valid() {
+                state.evaluated.extend(if_state.evaluated);
                 if self.then_.is_some() {
                     let schema_then_ = scope.resolve(self.then_.as_ref().unwrap());
 

--- a/src/json_schema/validators/conditional.rs
+++ b/src/json_schema/validators/conditional.rs
@@ -11,7 +11,13 @@ pub struct Conditional {
 }
 
 impl super::Validator for Conditional {
-    fn validate(&self, val: &Value, path: &str, scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let mut state = super::ValidationState::new();
 
         let schema_if_ = scope.resolve(&self.if_);
@@ -23,8 +29,7 @@ impl super::Validator for Conditional {
                     let schema_then_ = scope.resolve(self.then_.as_ref().unwrap());
 
                     if let Some(schema_then) = schema_then_ {
-                        let then_path = [path, "then"].join("/");
-                        state.append(schema_then.validate_in(val, then_path.as_ref()));
+                        state.append(schema_then.validate_in(val, path));
                     } else {
                         state.missing.push(self.then_.as_ref().unwrap().clone());
                     }
@@ -33,8 +38,7 @@ impl super::Validator for Conditional {
                 let schema_else_ = scope.resolve(self.else_.as_ref().unwrap());
 
                 if let Some(schema_else) = schema_else_ {
-                    let else_path = [path, "else"].join("/");
-                    state.append(schema_else.validate_in(val, else_path.as_ref()));
+                    state.append(schema_else.validate_in(val, path));
                 } else {
                     state.missing.push(self.else_.as_ref().unwrap().clone());
                 }

--- a/src/json_schema/validators/const_.rs
+++ b/src/json_schema/validators/const_.rs
@@ -10,13 +10,21 @@ pub struct Const {
 }
 
 impl super::Validator for Const {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let mut state = super::ValidationState::new();
 
         if !is_matching(&self.item, val) {
             state.errors.push(Box::new(errors::Const {
                 path: path.to_string(),
             }))
+        } else {
+            state.evaluated.insert(path.to_owned());
         }
 
         state

--- a/src/json_schema/validators/contains.rs
+++ b/src/json_schema/validators/contains.rs
@@ -12,7 +12,13 @@ pub struct Contains {
 }
 
 impl super::Validator for Contains {
-    fn validate(&self, val: &Value, path: &str, scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let mut array = Cow::Borrowed(nonstrict_process!(val.as_array(), path));
 
         let schema = scope.resolve(&self.url);

--- a/src/json_schema/validators/content_media.rs
+++ b/src/json_schema/validators/content_media.rs
@@ -12,7 +12,13 @@ pub struct ContentMedia {
 }
 
 impl super::Validator for ContentMedia {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let decoded_val = if self.encoding.is_some() && val.is_string() {
             let v = self
                 .encoding

--- a/src/json_schema/validators/content_media.rs
+++ b/src/json_schema/validators/content_media.rs
@@ -36,18 +36,18 @@ impl super::Validator for ContentMedia {
             val
         };
 
-        if self.type_.is_some() && val_.is_string() {
-            if !self
+        if self.type_.is_some()
+            && val_.is_string()
+            && !self
                 .type_
                 .as_ref()
                 .unwrap()
                 .validate(val_.as_str().unwrap())
-            {
-                return val_error!(errors::Format {
-                    path: path.to_string(),
-                    detail: "".to_string(),
-                });
-            }
+        {
+            return val_error!(errors::Format {
+                path: path.to_string(),
+                detail: "".to_string(),
+            });
         }
 
         super::ValidationState::new()

--- a/src/json_schema/validators/dependencies.rs
+++ b/src/json_schema/validators/dependencies.rs
@@ -17,7 +17,13 @@ pub struct Dependencies {
 }
 
 impl super::Validator for Dependencies {
-    fn validate(&self, val: &Value, path: &str, scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let mut state = super::ValidationState::new();
         if !val.is_object() {
             return state;

--- a/src/json_schema/validators/dependencies.rs
+++ b/src/json_schema/validators/dependencies.rs
@@ -1,6 +1,5 @@
 use serde_json::Value;
 use std::borrow::Cow;
-use std::collections;
 
 use super::super::errors;
 use super::super::scope;
@@ -13,7 +12,7 @@ pub enum DepKind {
 
 #[allow(missing_copy_implementations)]
 pub struct Dependencies {
-    pub items: collections::HashMap<String, DepKind>,
+    pub items: Vec<(String, DepKind)>,
 }
 
 impl super::Validator for Dependencies {

--- a/src/json_schema/validators/enum_.rs
+++ b/src/json_schema/validators/enum_.rs
@@ -10,7 +10,13 @@ pub struct Enum {
 }
 
 impl super::Validator for Enum {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let mut state = super::ValidationState::new();
 
         let mut contains = false;

--- a/src/json_schema/validators/formats.rs
+++ b/src/json_schema/validators/formats.rs
@@ -216,7 +216,7 @@ impl super::Validator for Time {
     fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
-        match chrono::NaiveTime::parse_from_str(string, "%H:%M:%S%.f%Z") {
+        match chrono::NaiveTime::parse_from_str(string, "%H:%M:%S%.f") {
             Ok(_) => super::ValidationState::new(),
             Err(_) => val_error!(errors::Format {
                 path: path.to_string(),

--- a/src/json_schema/validators/formats.rs
+++ b/src/json_schema/validators/formats.rs
@@ -242,7 +242,7 @@ impl super::Validator for Regex {
     ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
-        match regex::Regex::new(string) {
+        match fancy_regex::Regex::new(string) {
             Ok(_) => super::ValidationState::new(),
             Err(_) => val_error!(errors::Format {
                 path: path.to_string(),

--- a/src/json_schema/validators/formats.rs
+++ b/src/json_schema/validators/formats.rs
@@ -15,7 +15,13 @@ use super::super::scope;
 pub struct Date;
 
 impl super::Validator for Date {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
         match chrono::NaiveDate::parse_from_str(string, "%Y-%m-%d") {
@@ -41,7 +47,13 @@ impl super::Validator for Date {
 pub struct DateTime;
 
 impl super::Validator for DateTime {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
         match chrono::DateTime::parse_from_rfc3339(string) {
@@ -58,7 +70,13 @@ impl super::Validator for DateTime {
 pub struct Email;
 
 impl super::Validator for Email {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
         match List.parse_email_address(string) {
@@ -75,7 +93,13 @@ impl super::Validator for Email {
 pub struct Hostname;
 
 impl super::Validator for Hostname {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
         match List.parse_domain_name(string) {
@@ -92,7 +116,13 @@ impl super::Validator for Hostname {
 pub struct Ipv4;
 
 impl super::Validator for Ipv4 {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
         match string.parse::<net::Ipv4Addr>() {
@@ -109,7 +139,13 @@ impl super::Validator for Ipv4 {
 pub struct Ipv6;
 
 impl super::Validator for Ipv6 {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
         match string.parse::<net::Ipv6Addr>() {
@@ -126,7 +162,13 @@ impl super::Validator for Ipv6 {
 pub struct IRI;
 
 impl super::Validator for IRI {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
         match url::Url::parse(string) {
@@ -143,7 +185,13 @@ impl super::Validator for IRI {
 pub struct IRIReference;
 
 impl super::Validator for IRIReference {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
         let base_url = url::Url::parse("http://example.com/").unwrap();
@@ -162,7 +210,13 @@ impl super::Validator for IRIReference {
 pub struct JsonPointer;
 
 impl super::Validator for JsonPointer {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
         match string.parse::<json_pointer::JsonPointer<_, _>>() {
@@ -179,7 +233,13 @@ impl super::Validator for JsonPointer {
 pub struct Regex;
 
 impl super::Validator for Regex {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
         match regex::Regex::new(string) {
@@ -196,7 +256,13 @@ impl super::Validator for Regex {
 pub struct RelativeJsonPointer;
 
 impl super::Validator for RelativeJsonPointer {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
         match string.parse::<json_pointer::JsonPointer<_, _>>() {
@@ -213,7 +279,13 @@ impl super::Validator for RelativeJsonPointer {
 pub struct Time;
 
 impl super::Validator for Time {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
         match chrono::NaiveTime::parse_from_str(string, "%H:%M:%S%.f") {
@@ -230,7 +302,13 @@ impl super::Validator for Time {
 pub struct Uuid;
 
 impl super::Validator for Uuid {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
         match string.parse::<uuid::Uuid>() {
@@ -247,7 +325,13 @@ impl super::Validator for Uuid {
 pub struct Uri;
 
 impl super::Validator for Uri {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
         match url::Url::parse(string) {
@@ -264,7 +348,13 @@ impl super::Validator for Uri {
 pub struct UriReference;
 
 impl super::Validator for UriReference {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
         let base_url = url::Url::parse("http://example.com/").unwrap();
@@ -283,7 +373,13 @@ impl super::Validator for UriReference {
 pub struct UriTemplate;
 
 impl super::Validator for UriTemplate {
-    fn validate(&self, val: &Value, _path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        _path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
         let _ = uritemplate::UriTemplate::new(string);

--- a/src/json_schema/validators/maxmin.rs
+++ b/src/json_schema/validators/maxmin.rs
@@ -9,7 +9,13 @@ pub struct Maximum {
 }
 
 impl super::Validator for Maximum {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let number = nonstrict_process!(val.as_f64(), path);
 
         if number <= self.number {
@@ -28,7 +34,13 @@ pub struct ExclusiveMaximum {
 }
 
 impl super::Validator for ExclusiveMaximum {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let number = nonstrict_process!(val.as_f64(), path);
 
         if number < self.number {
@@ -47,7 +59,13 @@ pub struct Minimum {
 }
 
 impl super::Validator for Minimum {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let number = nonstrict_process!(val.as_f64(), path);
 
         if number >= self.number {
@@ -66,7 +84,13 @@ pub struct ExclusiveMinimum {
 }
 
 impl super::Validator for ExclusiveMinimum {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let number = nonstrict_process!(val.as_f64(), path);
 
         if number > self.number {

--- a/src/json_schema/validators/maxmin_items.rs
+++ b/src/json_schema/validators/maxmin_items.rs
@@ -9,7 +9,13 @@ pub struct MaxItems {
 }
 
 impl super::Validator for MaxItems {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let array = nonstrict_process!(val.as_array(), path);
 
         if (array.len() as u64) <= self.length {
@@ -28,7 +34,13 @@ pub struct MinItems {
 }
 
 impl super::Validator for MinItems {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let array = nonstrict_process!(val.as_array(), path);
 
         if (array.len() as u64) >= self.length {

--- a/src/json_schema/validators/maxmin_length.rs
+++ b/src/json_schema/validators/maxmin_length.rs
@@ -9,7 +9,13 @@ pub struct MaxLength {
 }
 
 impl super::Validator for MaxLength {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
         if (string.chars().count() as u64) <= self.length {
@@ -28,7 +34,13 @@ pub struct MinLength {
 }
 
 impl super::Validator for MinLength {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
         if (string.chars().count() as u64) >= self.length {

--- a/src/json_schema/validators/maxmin_properties.rs
+++ b/src/json_schema/validators/maxmin_properties.rs
@@ -9,7 +9,13 @@ pub struct MaxProperties {
 }
 
 impl super::Validator for MaxProperties {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let object = nonstrict_process!(val.as_object(), path);
 
         if (object.len() as u64) <= self.length {
@@ -28,7 +34,13 @@ pub struct MinProperties {
 }
 
 impl super::Validator for MinProperties {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let object = nonstrict_process!(val.as_object(), path);
 
         if (object.len() as u64) >= self.length {

--- a/src/json_schema/validators/mod.rs
+++ b/src/json_schema/validators/mod.rs
@@ -63,7 +63,7 @@ pub use self::property_names::PropertyNames;
 pub use self::ref_::Ref;
 pub use self::required::Required;
 pub use self::type_::Type;
-pub use self::unevaluated::UnevaluatedItems;
+pub use self::unevaluated::Unevaluated;
 pub use self::unique_items::UniqueItems;
 
 mod conditional;
@@ -87,7 +87,7 @@ mod property_names;
 mod ref_;
 mod required;
 pub mod type_;
-mod unevaluated;
+pub mod unevaluated;
 mod unique_items;
 
 #[derive(Debug)]

--- a/src/json_schema/validators/multiple_of.rs
+++ b/src/json_schema/validators/multiple_of.rs
@@ -18,10 +18,10 @@ impl super::Validator for MultipleOf {
             (number % self.number) == 0f64
         } else {
             let remainder: f64 = (number / self.number) % 1f64;
-            let remainder_less_than_epsilon = match remainder.partial_cmp(&f64::EPSILON) {
-                None | Some(Ordering::Less) => true,
-                _ => false,
-            };
+            let remainder_less_than_epsilon = matches!(
+                remainder.partial_cmp(&f64::EPSILON),
+                None | Some(Ordering::Less)
+            );
             let remainder_less_than_one = remainder < (1f64 - f64::EPSILON);
             remainder_less_than_epsilon && remainder_less_than_one
         };

--- a/src/json_schema/validators/multiple_of.rs
+++ b/src/json_schema/validators/multiple_of.rs
@@ -11,7 +11,13 @@ pub struct MultipleOf {
 }
 
 impl super::Validator for MultipleOf {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let number = nonstrict_process!(val.as_f64(), path);
 
         let valid = if (number.fract() == 0f64) && (self.number.fract() == 0f64) {

--- a/src/json_schema/validators/not.rs
+++ b/src/json_schema/validators/not.rs
@@ -9,7 +9,13 @@ pub struct Not {
 }
 
 impl super::Validator for Not {
-    fn validate(&self, val: &Value, path: &str, scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let schema = scope.resolve(&self.url);
         let mut state = super::ValidationState::new();
 

--- a/src/json_schema/validators/of.rs
+++ b/src/json_schema/validators/of.rs
@@ -1,5 +1,6 @@
 use serde_json::Value;
 use std::borrow::Cow;
+use std::collections::HashSet;
 
 use super::super::errors;
 use super::super::scope;
@@ -10,7 +11,13 @@ pub struct AllOf {
 }
 
 impl super::Validator for AllOf {
-    fn validate(&self, val: &Value, path: &str, scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let mut state = super::ValidationState::new();
         let mut val = Cow::Borrowed(val);
 
@@ -72,11 +79,19 @@ pub struct AnyOf {
 }
 
 impl super::Validator for AnyOf {
-    fn validate(&self, val: &Value, path: &str, scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let mut state = super::ValidationState::new();
         let mut val = Cow::Borrowed(val);
 
-        let mut states = vec![];
+        let mut invalid_states = vec![];
+        // The "best" state is defined as "the one that validates the most items".
+        let mut best_valid_state = None;
         let mut valid = false;
         for url in self.schemes.iter() {
             let schema = scope.resolve(url);
@@ -91,9 +106,17 @@ impl super::Validator for AnyOf {
                         *val.to_mut() = result;
                     }
                     valid = true;
-                    break;
+                    if result.evaluated.len()
+                        > best_valid_state
+                            .as_ref()
+                            .map(|v: &super::ValidationState| v.evaluated.len())
+                            .unwrap_or(0)
+                    {
+                        best_valid_state.replace(result);
+                    }
+                    // Cannot short-circuit here as "unevaluatedItems" requires that we find the "best" state.
                 } else {
-                    states.push(result)
+                    invalid_states.push(result)
                 }
             } else {
                 state.missing.push(url.clone())
@@ -103,8 +126,14 @@ impl super::Validator for AnyOf {
         if !valid {
             state.errors.push(Box::new(errors::AnyOf {
                 path: path.to_string(),
-                states,
+                states: invalid_states,
             }))
+        } else {
+            state.evaluated.extend(
+                best_valid_state
+                    .iter()
+                    .flat_map(|v| v.evaluated.iter().cloned()),
+            );
         }
 
         state.set_replacement(val);
@@ -118,12 +147,19 @@ pub struct OneOf {
 }
 
 impl super::Validator for OneOf {
-    fn validate(&self, val: &Value, path: &str, scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let mut state = super::ValidationState::new();
         let mut val = Cow::Borrowed(val);
 
         let mut states = vec![];
         let mut valid = 0;
+        let mut evaluated = HashSet::new();
         for url in self.schemes.iter() {
             let schema = scope.resolve(url);
 
@@ -137,6 +173,7 @@ impl super::Validator for OneOf {
                         *val.to_mut() = result;
                     }
                     valid += 1;
+                    evaluated = result.evaluated;
                 } else {
                     states.push(result)
                 }
@@ -150,6 +187,8 @@ impl super::Validator for OneOf {
                 path: path.to_string(),
                 states,
             }))
+        } else {
+            state.evaluated = evaluated;
         }
 
         state.set_replacement(val);

--- a/src/json_schema/validators/pattern.rs
+++ b/src/json_schema/validators/pattern.rs
@@ -1,4 +1,3 @@
-
 use serde_json::Value;
 
 use super::super::errors;

--- a/src/json_schema/validators/pattern.rs
+++ b/src/json_schema/validators/pattern.rs
@@ -9,7 +9,13 @@ pub struct Pattern {
 }
 
 impl super::Validator for Pattern {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
         if self.regex.is_match(string) {

--- a/src/json_schema/validators/pattern.rs
+++ b/src/json_schema/validators/pattern.rs
@@ -5,7 +5,7 @@ use super::super::scope;
 
 #[allow(missing_copy_implementations)]
 pub struct Pattern {
-    pub regex: regex::Regex,
+    pub regex: fancy_regex::Regex,
 }
 
 impl super::Validator for Pattern {
@@ -18,7 +18,7 @@ impl super::Validator for Pattern {
     ) -> super::ValidationState {
         let string = nonstrict_process!(val.as_str(), path);
 
-        if self.regex.is_match(string) {
+        if self.regex.is_match(string).unwrap_or(false) {
             super::ValidationState::new()
         } else {
             val_error!(errors::Pattern {

--- a/src/json_schema/validators/properties.rs
+++ b/src/json_schema/validators/properties.rs
@@ -16,7 +16,7 @@ pub enum AdditionalKind {
 pub struct Properties {
     pub properties: collections::HashMap<String, url::Url>,
     pub additional: AdditionalKind,
-    pub patterns: Vec<(regex::Regex, url::Url)>,
+    pub patterns: Vec<(fancy_regex::Regex, url::Url)>,
 }
 
 impl super::Validator for Properties {
@@ -71,7 +71,7 @@ impl super::Validator for Properties {
 
             let mut is_pattern_passed = false;
             for &(ref regex, ref url) in self.patterns.iter() {
-                if regex.is_match(key.as_ref()) {
+                if regex.is_match(key.as_ref()).unwrap_or(false) {
                     let schema = scope.resolve(url);
                     if let Some(schema) = schema {
                         let value_path = [path, key.as_ref()].join("/");

--- a/src/json_schema/validators/properties.rs
+++ b/src/json_schema/validators/properties.rs
@@ -19,7 +19,13 @@ pub struct Properties {
 }
 
 impl super::Validator for Properties {
-    fn validate(&self, val: &Value, path: &str, scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let mut object = Cow::Borrowed(nonstrict_process!(val.as_object(), path));
         let mut state = super::ValidationState::new();
 

--- a/src/json_schema/validators/properties.rs
+++ b/src/json_schema/validators/properties.rs
@@ -87,7 +87,7 @@ impl super::Validator for Properties {
                 AdditionalKind::Boolean(allowed) if !allowed => {
                     state.errors.push(Box::new(errors::Properties {
                         path: path.to_string(),
-                        detail: format!("Additional property '{}' is not allowed", key)
+                        detail: format!("Additional property '{}' is not allowed", key),
                     }))
                 }
                 AdditionalKind::Schema(ref url) => {

--- a/src/json_schema/validators/property_names.rs
+++ b/src/json_schema/validators/property_names.rs
@@ -8,7 +8,13 @@ pub struct PropertyNames {
 }
 
 impl super::Validator for PropertyNames {
-    fn validate(&self, val: &Value, path: &str, scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let object = nonstrict_process!(val.as_object(), path);
 
         let schema = scope.resolve(&self.url);

--- a/src/json_schema/validators/ref_.rs
+++ b/src/json_schema/validators/ref_.rs
@@ -8,7 +8,13 @@ pub struct Ref {
 }
 
 impl super::Validator for Ref {
-    fn validate(&self, val: &Value, path: &str, scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let schema = scope.resolve(&self.url);
 
         if let Some(schema) = schema {

--- a/src/json_schema/validators/required.rs
+++ b/src/json_schema/validators/required.rs
@@ -9,7 +9,13 @@ pub struct Required {
 }
 
 impl super::Validator for Required {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let object = nonstrict_process!(val.as_object(), path);
         let mut state = super::ValidationState::new();
 

--- a/src/json_schema/validators/type_.rs
+++ b/src/json_schema/validators/type_.rs
@@ -33,7 +33,13 @@ fn check_type(val: &Value, ty: json_schema::PrimitiveType) -> bool {
 }
 
 impl super::Validator for Type {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let mut state = super::ValidationState::new();
 
         match self.item {
@@ -43,6 +49,8 @@ impl super::Validator for Type {
                         path: path.to_string(),
                         detail: format!("The value must be {}", t),
                     }))
+                } else {
+                    state.evaluated.insert(path.to_owned());
                 }
             }
             TypeKind::Set(ref set) => {
@@ -65,6 +73,8 @@ impl super::Validator for Type {
                                 .join(", ")
                         ),
                     }))
+                } else {
+                    state.evaluated.insert(path.to_owned());
                 }
             }
         }

--- a/src/json_schema/validators/unevaluated.rs
+++ b/src/json_schema/validators/unevaluated.rs
@@ -2,12 +2,60 @@ use std::{borrow::Cow, collections::HashSet};
 
 use crate::json_schema::errors;
 
-pub enum UnevaluatedItems {
+pub enum UnevaluatedSchema {
     Bool(bool),
     Schema(url::Url),
 }
 
-impl super::Validator for UnevaluatedItems {
+pub struct Unevaluated {
+    pub is_items: bool,
+    pub schema: UnevaluatedSchema,
+}
+
+impl Unevaluated {
+    fn check_one_item(
+        &self,
+        item_path: String,
+        item: &serde_json::Value,
+        scope: &crate::json_schema::scope::Scope,
+    ) -> super::ValidationState {
+        let mut state = super::ValidationState::new();
+        match self.schema {
+            UnevaluatedSchema::Bool(allow_unevaluated) => {
+                if !allow_unevaluated {
+                    state.errors.push(Box::new(errors::Unevaluated {
+                        path: item_path,
+                        detail: if self.is_items {
+                            "Unevaluated items are not allowed".to_string()
+                        } else {
+                            "Unevaluated properties are not allowed".to_string()
+                        },
+                    }));
+                } else {
+                    state.evaluated.insert(item_path);
+                }
+            }
+            UnevaluatedSchema::Schema(ref url) => {
+                let schema = scope.resolve(url);
+                if let Some(schema) = schema {
+                    let mut result = schema.validate_in(item, item_path.as_ref());
+                    if result.is_valid() {
+                        state.evaluated.insert(item_path);
+                        state.replacement = result.replacement.take();
+                    }
+
+                    state.append(result);
+                } else {
+                    state.missing.push(url.clone())
+                }
+            }
+        }
+
+        state
+    }
+}
+
+impl super::Validator for Unevaluated {
     fn validate(
         &self,
         val: &serde_json::Value,
@@ -20,44 +68,48 @@ impl super::Validator for UnevaluatedItems {
             .iter()
             .filter(|i| i.starts_with(path))
             .collect();
-
-        let mut array = Cow::Borrowed(nonstrict_process!(val.as_array(), path));
         let mut state = super::ValidationState::new();
 
-        for idx in 0..array.len() {
-            let item_path = [path, idx.to_string().as_ref()].join("/");
-            let item = &array[idx];
-            if evaluated_children.contains(&item_path) {
-                continue;
+        if self.is_items {
+            let mut array = Cow::Borrowed(nonstrict_process!(val.as_array(), path));
+
+            for idx in 0..array.len() {
+                let item_path = [path, idx.to_string().as_ref()].join("/");
+                let item = &array[idx];
+                if evaluated_children.contains(&item_path) {
+                    continue;
+                }
+
+                let mut result = self.check_one_item(item_path, item, scope);
+                if result.replacement.is_some() {
+                    array.to_mut()[idx] = result.replacement.take().unwrap();
+                }
+                state.append(result);
             }
 
-            match self {
-                UnevaluatedItems::Bool(allow_unevaluated) => {
-                    if !allow_unevaluated {
-                        state.errors.push(Box::new(errors::Items {
-                            path: item_path,
-                            detail: "Unevaluated items are not allowed".to_string(),
-                        }));
-                    } else {
-                        state.evaluated.insert(item_path);
-                    }
-                }
-                UnevaluatedItems::Schema(ref url) => {
-                    let schema = scope.resolve(url);
-                    if let Some(schema) = schema {
-                        let mut result = schema.validate_in(item, item_path.as_ref());
-                        if result.is_valid() {
-                            state.evaluated.insert(item_path);
-                            if result.replacement.is_some() {
-                                array.to_mut()[idx] = result.replacement.take().unwrap();
-                            }
-                        }
+            state.set_replacement(array);
+        } else {
+            let mut object = nonstrict_process!(val.as_object(), path).clone();
+            let mut changed = false;
+            for (k, item) in object.iter_mut() {
+                let item_path = [path, k].join("/");
 
-                        state.append(result);
-                    } else {
-                        state.missing.push(url.clone())
-                    }
+                if evaluated_children.contains(&item_path) {
+                    continue;
                 }
+
+                let mut result = self.check_one_item(item_path, item, scope);
+                if result.replacement.is_some() {
+                    *item = result.replacement.take().unwrap();
+                    changed = true;
+                }
+                state.append(result);
+            }
+
+            if changed {
+                state.set_replacement(std::borrow::Cow::Owned::<
+                    serde_json::Map<String, serde_json::Value>,
+                >(object));
             }
         }
 

--- a/src/json_schema/validators/unevaluated.rs
+++ b/src/json_schema/validators/unevaluated.rs
@@ -1,0 +1,66 @@
+use std::{borrow::Cow, collections::HashSet};
+
+use crate::json_schema::errors;
+
+pub enum UnevaluatedItems {
+    Bool(bool),
+    Schema(url::Url),
+}
+
+impl super::Validator for UnevaluatedItems {
+    fn validate(
+        &self,
+        val: &serde_json::Value,
+        path: &str,
+        scope: &crate::json_schema::scope::Scope,
+        state: &super::ValidationState,
+    ) -> super::ValidationState {
+        let evaluated_children: HashSet<_> = state
+            .evaluated
+            .iter()
+            .filter(|i| i.starts_with(path))
+            .collect();
+
+        let mut array = Cow::Borrowed(nonstrict_process!(val.as_array(), path));
+        let mut state = super::ValidationState::new();
+
+        for idx in 0..array.len() {
+            let item_path = [path, idx.to_string().as_ref()].join("/");
+            let item = &array[idx];
+            if evaluated_children.contains(&item_path) {
+                continue;
+            }
+
+            match self {
+                UnevaluatedItems::Bool(allow_unevaluated) => {
+                    if !allow_unevaluated {
+                        state.errors.push(Box::new(errors::Items {
+                            path: item_path,
+                            detail: "Unevaluated items are not allowed".to_string(),
+                        }));
+                    } else {
+                        state.evaluated.insert(item_path);
+                    }
+                }
+                UnevaluatedItems::Schema(ref url) => {
+                    let schema = scope.resolve(url);
+                    if let Some(schema) = schema {
+                        let mut result = schema.validate_in(item, item_path.as_ref());
+                        if result.is_valid() {
+                            state.evaluated.insert(item_path);
+                            if result.replacement.is_some() {
+                                array.to_mut()[idx] = result.replacement.take().unwrap();
+                            }
+                        }
+
+                        state.append(result);
+                    } else {
+                        state.missing.push(url.clone())
+                    }
+                }
+            }
+        }
+
+        state
+    }
+}

--- a/src/json_schema/validators/unique_items.rs
+++ b/src/json_schema/validators/unique_items.rs
@@ -6,7 +6,13 @@ use super::super::scope;
 #[allow(missing_copy_implementations)]
 pub struct UniqueItems;
 impl super::Validator for UniqueItems {
-    fn validate(&self, val: &Value, path: &str, _scope: &scope::Scope) -> super::ValidationState {
+    fn validate(
+        &self,
+        val: &Value,
+        path: &str,
+        _scope: &scope::Scope,
+        _: &super::ValidationState,
+    ) -> super::ValidationState {
         let array = nonstrict_process!(val.as_array(), path);
 
         // TODO we need some quicker algorithm for this

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::new_without_default)]
+#![allow(clippy::bool_assert_comparison, clippy::new_without_default)]
 
 #[macro_use]
 extern crate serde_json;

--- a/tests/dsl/mod.rs
+++ b/tests/dsl/mod.rs
@@ -268,7 +268,7 @@ fn is_validates_with_regex() {
     let params = json_dsl::Builder::build(|params| {
         params.req("a", |a| {
             a.coerce(json_dsl::string());
-            a.regex(regex::Regex::new("^test$").unwrap());
+            a.regex(fancy_regex::Regex::new("^test$").unwrap());
         })
     });
 
@@ -282,7 +282,7 @@ fn is_validates_with_regex() {
         params.req("a", |a| {
             // regex can't be applied to list, so it will never be valid
             a.coerce(json_dsl::array());
-            a.regex(regex::Regex::new("^test$").unwrap());
+            a.regex(fancy_regex::Regex::new("^test$").unwrap());
         })
     });
 

--- a/tests/schema/mod.rs
+++ b/tests/schema/mod.rs
@@ -47,7 +47,7 @@ fn test_suite() {
     println!("test json_schema::test_suite");
 
     visit_specs(
-        &path::Path::new("tests/schema/JSON-Schema-Test-Suite/tests/draft7"),
+        path::Path::new("tests/schema/JSON-Schema-Test-Suite/tests/draft7"),
         |path, spec_set: Value| {
             let spec_set = spec_set.as_array().unwrap();
 
@@ -280,7 +280,7 @@ fn test_suite() {
                         continue;
                     }
 
-                    let state = schema.validate(&data);
+                    let state = schema.validate(data);
 
                     // TODO implement remote schema download for strict validation
                     if state.is_valid() != valid {
@@ -288,7 +288,7 @@ fn test_suite() {
                             "Failure: \"{}\" in \"{}\" -> \"{}\" with state: \n {}",
                             path.file_name().unwrap().to_str().unwrap(),
                             spec_desc,
-                            description.to_string(),
+                            description,
                             to_string_pretty(&to_value(&state).unwrap()).unwrap()
                         )
                     } else {

--- a/tests/schema/mod.rs
+++ b/tests/schema/mod.rs
@@ -8,7 +8,10 @@ fn visit_specs<F>(dir: &path::Path, cb: F)
 where
     F: Fn(&path::Path, Value) + Copy,
 {
-    let contents = fs::read_dir(dir).expect(&*format!("cannot list directory {:?}", dir));
+    let mut contents = fs::read_dir(dir)
+        .expect(&*format!("cannot list directory {:?}", dir))
+        .collect::<Vec<_>>();
+    contents.sort_by_key(|v| v.as_ref().unwrap().file_name());
     for entry in contents {
         let entry = entry.unwrap();
         let path = entry.path();

--- a/tests/schema/mod.rs
+++ b/tests/schema/mod.rs
@@ -482,7 +482,7 @@ fn test_suite_draft201909() {
                 ),
                 (
                     // TODO implement remote schema download
-                    "definitions.json".to_string(),
+                    "defs.json".to_string(),
                     "invalid definition".to_string(),
                 ),
                 (

--- a/tests/schema/mod.rs
+++ b/tests/schema/mod.rs
@@ -489,6 +489,11 @@ fn test_suite_draft201909() {
                     "invalid definition".to_string(),
                 ),
                 (
+                    // TODO implement remote schema download
+                    "id.json".to_string(),
+                    "Invalid use of fragments in location-independent $id".to_string(),
+                ),
+                (
                     "idn-hostname.json".to_string(),
                     "validation of internationalized host names".to_string(),
                 ),
@@ -500,6 +505,16 @@ fn test_suite_draft201909() {
                     // optional overflow handling is not implemented
                     "float-overflow.json".to_string(),
                     "all integers are multiples of 0.5, if overflow is handled".to_string(),
+                ),
+                (
+                    // TODO implement duration validation
+                    "duration.json".to_string(),
+                    "validation of duration strings".to_string(),
+                ),
+                (
+                    // TODO implement UUID validation
+                    "uuid.json".to_string(),
+                    "uuid format".to_string(),
                 ),
             ];
 

--- a/tests/schema/mod.rs
+++ b/tests/schema/mod.rs
@@ -2,7 +2,7 @@ use serde_json::{from_str, to_string_pretty, to_value, Value};
 use std::fs;
 use std::io::Read;
 use std::path;
-use valico::json_schema;
+use valico::json_schema::{self, SchemaVersion};
 
 fn visit_specs<F>(dir: &path::Path, cb: F)
 where
@@ -32,7 +32,7 @@ where
 }
 
 #[test]
-fn test_suite() {
+fn test_suite_draft7() {
     let mut content = String::new();
 
     fs::File::open(&path::Path::new("tests/schema/schema.json"))
@@ -44,7 +44,7 @@ fn test_suite() {
 
     let json_v7_schema: Value = from_str(&content).unwrap();
 
-    println!("test json_schema::test_suite");
+    println!("test json_schema::test_suite_draft7");
 
     visit_specs(
         path::Path::new("tests/schema/JSON-Schema-Test-Suite/tests/draft7"),
@@ -234,6 +234,275 @@ fn test_suite() {
             for spec in spec_set.iter() {
                 let spec = spec.as_object().unwrap();
                 let mut scope = json_schema::Scope::new();
+
+                scope.compile(json_v7_schema.clone(), true).ok().unwrap();
+
+                let spec_desc = spec
+                    .get("description")
+                    .map(|v| v.as_str().unwrap())
+                    .unwrap_or("");
+                let spec_exception_found = group_exceptions[..].contains(&(
+                    path.file_name().unwrap().to_str().unwrap().to_string(),
+                    spec_desc.to_string(),
+                ));
+                if spec_exception_found {
+                    println!("\t\t{} .. skipped", spec_desc);
+                    continue;
+                } else {
+                    println!("\t\t{}", spec_desc);
+                }
+
+                let schema =
+                    match scope.compile_and_return(spec.get("schema").unwrap().clone(), false) {
+                        Ok(schema) => schema,
+                        Err(err) => panic!(
+                            "Error in schema {} {}: {:?}",
+                            path.file_name().unwrap().to_str().unwrap(),
+                            spec.get("description").unwrap().as_str().unwrap(),
+                            err
+                        ),
+                    };
+
+                let tests = spec.get("tests").unwrap().as_array().unwrap();
+
+                for test in tests.iter() {
+                    let test = test.as_object().unwrap();
+                    let description = test.get("description").unwrap().as_str().unwrap();
+                    let data = test.get("data").unwrap();
+                    let valid = test.get("valid").unwrap().as_bool().unwrap();
+
+                    let exception_found = exceptions[..].contains(&(
+                        path.file_name().unwrap().to_str().unwrap().to_string(),
+                        description.to_string(),
+                    ));
+                    if exception_found {
+                        println!("\t\t\t{} .. skipped", description);
+                        continue;
+                    }
+
+                    let state = schema.validate(data);
+
+                    // TODO implement remote schema download for strict validation
+                    if state.is_valid() != valid {
+                        panic!(
+                            "Failure: \"{}\" in \"{}\" -> \"{}\" with state: \n {}",
+                            path.file_name().unwrap().to_str().unwrap(),
+                            spec_desc,
+                            description,
+                            to_string_pretty(&to_value(&state).unwrap()).unwrap()
+                        )
+                    } else {
+                        println!("\t\t\t{} .. ok", description);
+                    }
+                }
+            }
+        },
+    )
+}
+
+#[test]
+fn test_suite_draft201909() {
+    let mut content = String::new();
+
+    fs::File::open(path::Path::new("tests/schema/schema.json"))
+        .ok()
+        .unwrap()
+        .read_to_string(&mut content)
+        .ok()
+        .unwrap();
+
+    let json_v7_schema: Value = from_str(&content).unwrap();
+
+    println!("test json_schema::test_suite_draft201909");
+
+    visit_specs(
+        path::Path::new("tests/schema/JSON-Schema-Test-Suite/tests/draft2019-09"),
+        |path, spec_set: Value| {
+            let spec_set = spec_set.as_array().unwrap();
+
+            println!(
+                "\t{}",
+                path.file_name()
+                    .unwrap_or_default()
+                    .to_str()
+                    .unwrap_or_default()
+            );
+
+            let exceptions: Vec<(String, String)> = vec![
+                (
+                    "minLength.json".to_string(),
+                    "one supplementary Unicode code point is not long enough".to_string(),
+                ),
+                (
+                    // TODO implement remote schema download
+                    "refRemote.json".to_string(),
+                    "remote ref invalid".to_string(),
+                ),
+                (
+                    // TODO implement remote schema download
+                    "refRemote.json".to_string(),
+                    "remote fragment invalid".to_string(),
+                ),
+                (
+                    // TODO implement remote schema download
+                    "refRemote.json".to_string(),
+                    "ref within ref invalid".to_string(),
+                ),
+                (
+                    // TODO implement remote schema download
+                    "refRemote.json".to_string(),
+                    "changed scope ref invalid".to_string(),
+                ),
+                (
+                    // TODO implement remote schema download
+                    "refRemote.json".to_string(),
+                    "base URI change ref invalid".to_string(),
+                ),
+                (
+                    // TODO implement remote schema download
+                    "refRemote.json".to_string(),
+                    "string is invalid".to_string(),
+                ),
+                (
+                    // TODO implement remote schema download
+                    "refRemote.json".to_string(),
+                    "object is invalid".to_string(),
+                ),
+                (
+                    "bignum.json".to_string(),
+                    "a bignum is an integer".to_string(),
+                ),
+                (
+                    "bignum.json".to_string(),
+                    "a negative bignum is an integer".to_string(),
+                ),
+                (
+                    "uri-reference.json".to_string(),
+                    "an invalid URI Reference".to_string(),
+                ),
+                (
+                    "uri-reference.json".to_string(),
+                    "an invalid URI fragment".to_string(),
+                ),
+                (
+                    "ecmascript-regex.json".to_string(),
+                    "ECMA 262 has no support for \\Z anchor from .NET".to_string(),
+                ),
+                (
+                    "ecmascript-regex.json".to_string(),
+                    "latin-1 non-breaking-space does not match (unlike e.g. Python)".to_string(),
+                ),
+                (
+                    "ecmascript-regex.json".to_string(),
+                    "latin-1 non-breaking-space matches (unlike e.g. Python)".to_string(),
+                ),
+                (
+                    "ecmascript-regex.json".to_string(),
+                    "zero-width whitespace matches".to_string(),
+                ),
+                (
+                    "ecmascript-regex.json".to_string(),
+                    "zero-width whitespace does not match".to_string(),
+                ),
+                (
+                    // TODO handle these "empty" edge cases in json-pointer
+                    "json-pointer.json".to_string(),
+                    "not a valid JSON-pointer (URI Fragment Identifier) #1".to_string(),
+                ),
+                (
+                    // TODO handle these "empty" edge cases in json-pointer
+                    "json-pointer.json".to_string(),
+                    "not a valid JSON-pointer (URI Fragment Identifier) #2".to_string(),
+                ),
+                (
+                    // TODO handle these "empty" edge cases in json-pointer
+                    "json-pointer.json".to_string(),
+                    "not a valid JSON-pointer (URI Fragment Identifier) #3".to_string(),
+                ),
+                (
+                    // I believe it is trimmed as it is at the beginning, it works when inside.
+                    "idn-hostname.json".to_string(),
+                    "contains illegal char U+302E Hangul single dot tone mark".to_string(),
+                ),
+                (
+                    // TODO uritemplate needs fixes/changes but the maintainer is inactive.
+                    "uri-template.json".to_string(),
+                    "an invalid uri-template".to_string(),
+                ),
+                (
+                    // https://github.com/chronotope/chrono/issues/288
+                    "time.json".to_string(),
+                    "a valid time string".to_string(),
+                ),
+                (
+                    // TODO implement remote schema download
+                    "ref.json".to_string(),
+                    "remote ref invalid".to_string(),
+                ),
+                (
+                    // same as URI
+                    "iri-reference.json".to_string(),
+                    "an invalid IRI Reference".to_string(),
+                ),
+                (
+                    // same as URI
+                    "iri-reference.json".to_string(),
+                    "an invalid IRI fragment".to_string(),
+                ),
+            ];
+            let group_exceptions: Vec<(String, String)> = vec![
+                (
+                    "ecmascript-regex.json".to_string(),
+                    "ECMA 262 regex escapes control codes with \\c and upper letter".to_string(),
+                ),
+                (
+                    "ecmascript-regex.json".to_string(),
+                    "ECMA 262 regex escapes control codes with \\c and lower letter".to_string(),
+                ),
+                (
+                    "ecmascript-regex.json".to_string(),
+                    "ECMA 262 \\d matches ascii digits only".to_string(),
+                ),
+                (
+                    "ecmascript-regex.json".to_string(),
+                    "ECMA 262 \\D matches everything but ascii digits".to_string(),
+                ),
+                (
+                    "ecmascript-regex.json".to_string(),
+                    "ECMA 262 \\w matches ascii letters only".to_string(),
+                ),
+                (
+                    "ecmascript-regex.json".to_string(),
+                    "ECMA 262 \\W matches everything but ascii letters".to_string(),
+                ),
+                (
+                    // TODO json-pointer needs to handle relative JSON pointers
+                    "relative-json-pointer.json".to_string(),
+                    "validation of Relative JSON Pointers (RJP)".to_string(),
+                ),
+                (
+                    // TODO implement remote schema download
+                    "definitions.json".to_string(),
+                    "invalid definition".to_string(),
+                ),
+                (
+                    "idn-hostname.json".to_string(),
+                    "validation of internationalized host names".to_string(),
+                ),
+                (
+                    "email.json".to_string(),
+                    "validation of e-mail addresses".to_string(),
+                ),
+                (
+                    // optional overflow handling is not implemented
+                    "float-overflow.json".to_string(),
+                    "all integers are multiples of 0.5, if overflow is handled".to_string(),
+                ),
+            ];
+
+            for spec in spec_set.iter() {
+                let spec = spec.as_object().unwrap();
+                let mut scope = json_schema::Scope::new().set_version(SchemaVersion::Draft2019_09);
 
                 scope.compile(json_v7_schema.clone(), true).ok().unwrap();
 


### PR DESCRIPTION
This passes the draft2019 tests that are already in the repo. 

It builds off the two PRs by erickt.

It implements:

* unevaluatedItems/unevaluatedProperties
* dependentRequired/dependentSchemas
* minContains/maxContains

still missing are:

* $recursiveRef and $recursiveAnchor
* $vocabulary